### PR TITLE
RDKBACCL-365,RDKBACCL-289 : Added WebPA and UspPA features support in BPI R4 Builds

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -1,0 +1,2 @@
+# USP-PA Feature
+DISTRO_FEATURES_append = " usppa"

--- a/conf/include/rdk-bpi-bbmasks.inc
+++ b/conf/include/rdk-bpi-bbmasks.inc
@@ -1,0 +1,1 @@
+BBMASK .= "|meta-cmf-filogic/recipes-extended/tdkb/"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,0 +1,18 @@
+BBPATH .= ":${LAYERDIR}"
+BBFILES += "\
+            ${LAYERDIR}/meta*/recipes-*/*/*.bb \
+            ${LAYERDIR}/meta*/recipes-*/*/*.bbappend \
+            ${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend \
+           "
+
+BBFILE_COLLECTIONS += "cmf-bananapi"
+BBFILE_PATTERN_cmf-bananapi := "^${LAYERDIR}/"
+
+LAYERDEPENDS_cmf-bananapi = "cmf-filogic"
+LAYERDEPENDS_cmf-bananapi_append = " filogic"
+
+require conf/include/rdk-bpi-bbmasks.inc
+require conf/distro/include/rdk-bpi.inc
+
+LAYERSERIES_COMPAT_cmf-bananapi = " kirkstone"

--- a/conf/machine/bananapi4-rdk-broadband.conf
+++ b/conf/machine/bananapi4-rdk-broadband.conf
@@ -1,0 +1,7 @@
+#@TYPE: Machine
+#@NAME: bananapi4-rdk-broadband
+#@NEEDED_BSPLAYERS: meta-cmf-bananapi
+#@DESCRIPTION: Machine configuration for running a RDK broadband on Banana Pi R4
+#@RDK_FLAVOR: rdkb
+
+require conf/machine/filogic880-bpi-r4.conf

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/parodus2ccsp.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/parodus2ccsp.bbappend
@@ -1,0 +1,26 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/parodus2ccsp:"
+ 
+SRC_URI_append = " \
+    ${CMF_GIT_ROOT}/rdk/devices/raspberrypi/webpa-client;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};destsuffix=git/devices;name=rdkbbpi \
+"
+SRCREV_rdkbbpi = "${AUTOREV}"
+do_fetch[vardeps] += "SRCREV_rdkbbpi"
+SRCREV_FORMAT .= "_rdkbbpi"
+
+inherit systemd coverity
+
+EXTRA_OECMAKE += "-DBUILD_BANANAPI_R4=ON "
+ 
+do_install_append () {
+    install -d ${D}${systemd_unitdir}/system
+    install -d ${D}${base_libdir_native}/rdk
+    install -m 0644 ${S}/devices/broadband/parodus2ccsp/systemd/webpabroadband.service ${D}${systemd_unitdir}/system
+    install -m 0755 ${S}/devices/broadband/parodus2ccsp/scripts/webpa_pre_setup.sh ${D}${base_libdir_native}/rdk
+}
+
+SYSTEMD_SERVICE_${PN}_append = " webpabroadband.service"
+ 
+FILES_${PN}_append = " \
+     ${systemd_unitdir}/system/webpabroadband.service \
+     ${base_libdir_native}/rdk/* \
+     "

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -1,0 +1,2 @@
+#WebPA Feature
+IMAGE_INSTALL_append = " parodus parodus2ccsp"

--- a/meta-rdk-mtk-bpir4/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -1,0 +1,4 @@
+do_install_append () {
+  #Webpa ServerURL
+  echo "SERVERURL=http://webpa.rdkcentral.com:8080" >> ${D}${sysconfdir}/device.properties
+}

--- a/meta-rdk-mtk-bpir4/recipes-rdkb/usp-pa/usp-pa.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-rdkb/usp-pa/usp-pa.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF_remove_kirkstone  = " --with-ccsp-platform=bcm --with-ccsp-arch=arm "

--- a/meta-rdk-mtk-bpir4/recipes-support/parodus/parodus_1.0.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-support/parodus/parodus_1.0.bbappend
@@ -1,0 +1,23 @@
+LDFLAGS_append = " -Wl,--no-as-needed -lm -llog4c -lrdkloggers"
+inherit systemd coverity
+ 
+SRC_URI_append = " \
+        ${CMF_GIT_ROOT}/rdk/devices/raspberrypi/webpa-client;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};destsuffix=git/devices;name=rdkbbpi \
+"
+SRCREV_rdkbbpi = "${AUTOREV}"
+do_fetch[vardeps] += "SRCREV_rdkbbpi"
+SRCREV_FORMAT .= "_rdkbbpi"
+ 
+do_install_append () {
+    install -d ${D}${systemd_unitdir}/system
+    install -d ${D}${base_libdir_native}/rdk
+    install -m 0644 ${S}/devices/broadband/parodus/systemd/parodus.service ${D}${systemd_unitdir}/system
+    install -m 0755 ${S}/devices/broadband/parodus/scripts/parodus_start.sh ${D}${base_libdir_native}/rdk
+}
+
+SYSTEMD_SERVICE_${PN}_append = " parodus.service"
+ 
+FILES_${PN}_append = " \
+     ${systemd_unitdir}/system/parodus.service \
+     ${base_libdir_native}/rdk/* \
+"

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -3,7 +3,7 @@
 # If not stated otherwise in this file or this component's LICENSE
 # file the following copyright and licenses apply:
 #
-# Copyright 2014 RDK Management
+# Copyright 2024 RDK Management
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,20 @@
 # Save _TOPDIR
 _TOPDIR=`pwd`
 
+export RDK_BSP_LAYER=none
+
 #select filogic880-bpi-r4.conf for BPI R4
 if [ -e "${_TOPDIR}/meta-cmf-filogic/setup-environment-release" ]; then
 	source meta-cmf-filogic/setup-environment-release
 fi
+
+
+if [[ -z $(grep 'meta-cmf-bananapi' conf/bblayers.conf) ]] && [[ -d  ../meta-cmf-bananapi ]]
+then
+    cat >> conf/bblayers.conf <<EOF
+BBLAYERS =+ "\${RDKROOT}/meta-cmf-bananapi"
+EOF
+fi
+
+# default BSP layer is meta-cmf-bananapi for B-PI builds
+export RDK_BSP_LAYER=meta-cmf-bananapi


### PR DESCRIPTION
Reason for change: Added required changes in cmf-bananapi layer to support the WebPA and UspPA feature for BPI R4 reference device. 
Test Procedure: Updated Test Results in JIRA
Risks: Low