### PR TITLE
RDKBACCL-274 :  Adding meta layers

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
@@ -1,0 +1,3 @@
+include recipes-ccsp/ccsp/ccsp_common_bananapi.inc
+
+CFLAGS_append  = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '-DFEATURE_RDKB_WAN_MANAGER', '', d)}"


### PR DESCRIPTION
RDKBACCL-274 :  Adding meta layers and removing Turris flag

Reason for change : Integration of ccsp components after removing Turris flag
Test Procedure: Build and flash the image.erouter0 should get ip
Risks: None