### PR TITLE
RDKBACCL-274 :  Adding meta layers

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/test-and-diagnostic.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/test-and-diagnostic.bbappend
@@ -1,0 +1,1 @@
+include recipes-ccsp/ccsp/ccsp_common_bananapi.inc

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -1,0 +1,16 @@
+include recipes-ccsp/ccsp/ccsp_common_bananapi.inc
+
+
+do_install_append() {
+
+    install -d ${D}${sysconfdir}/
+    install -d ${D}${sysconfdir}/utopia/	
+    DISTRO_WAN_ENABLED="${@bb.utils.contains('DISTRO_FEATURES','rdkb_wan_manager','true','false',d)}"
+    if [ $DISTRO_WAN_ENABLED = 'true' ]; then
+      sed '/\/tmp\/dibbler/d' ${D}${sysconfdir}/utopia/utopia_init.sh
+mkdir -p \/etc \
+mkdir -p \/etc\/dibbler \
+ln -s \/etc\/dibbler \/tmp \
+touch \/etc\/dibbler\/radvd.conf \
+    fi
+}


### PR DESCRIPTION
RDKBACCL-274 :  Adding meta layers and removing Turris flag

Reason for change : Integration of ccsp components after removing Turris flag
Test Procedure: Build and flash the image.erouter0 should get ip
Risks: None