### PR TITLE
RDKBACCL-364,RDKBACCL-356 : Bringup onewifi

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -7,3 +7,17 @@ DISTRO_FEATURES_append = " rdkb_wan_manager"
 
 CFLAGS_append  = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '-DFEATURE_RDKB_WAN_MANAGER', '', d)}"
 
+DISTRO_FEATURES_append = " halVersion3"
+
+#rdk-wifi-libhostap support for broadband
+DISTRO_FEATURES_append = " HOSTAPD_2_10"
+
+# OneWifi feature
+#DISTRO_FEATURES_append = " OneWifi"
+
+# MacFilter Feature
+DISTRO_FEATURES_append = " acl_nl_support"
+
+DISTRO_FEATURES_append = " referencepltfm "
+
+MACHINEOVERRIDES_append =. "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ':onewifi', '' ,d)}"

--- a/conf/include/rdk-bpi-bbmasks.inc
+++ b/conf/include/rdk-bpi-bbmasks.inc
@@ -1,1 +1,5 @@
 BBMASK .= "|meta-cmf-filogic/recipes-extended/tdkb/"
+
+BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '|meta-filogic/recipes-wifi/hostapd/', '', d)}"
+BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '|meta-filogic/recipes-wifi/hal/halinterface.bbappend', '', d)}"
+BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '|meta-cmf-filogic/recipes-common/mesh-agent/mesh-agent.bbappend', '', d)}"

--- a/conf/machine/bananapi4-rdk-broadband.conf
+++ b/conf/machine/bananapi4-rdk-broadband.conf
@@ -5,3 +5,6 @@
 #@RDK_FLAVOR: rdkb
 
 require conf/machine/filogic880-bpi-r4.conf
+
+require conf/distro/include/rdk-bpi.inc 
+PREFERRED_PROVIDER_hal-wifi_onewifi = "hal-wifi-generic"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -1,0 +1,24 @@
+include ccsp_common_bananapi.inc
+
+CFLAGS_aarch64_append = " -Werror=format-truncation=1 "
+
+do_install_append_class-target() {
+   sed -i 's#${PARODUS_START_LOG_FILE}#/rdklogs/logs/dcmrfc.log#g' ${D}${systemd_unitdir}/system/rfc.service
+   sed -i 's/rfc.service /RFCbase.sh /g' ${D}${systemd_unitdir}/system/rfc.service
+
+   DISTRO_OneWiFi_ENABLED="${@bb.utils.contains('DISTRO_FEATURES','OneWifi','true','false',d)}"
+   if [ $DISTRO_OneWiFi_ENABLED = 'true' ]; then
+        install -D -m 0644 ${S}/systemd_units/onewifi.service ${D}${systemd_unitdir}/system/onewifi.service
+        sed -i "s/Unit=ccspwifiagent.service/Unit=onewifi.service/g"  ${D}${systemd_unitdir}/system/filogicwifiinitialized.path
+        sed -i "/OSW_DRV_TARGET_DISABLED=1/a ExecStartPre=\/bin\/sh \/usr\/ccsp\/wifi\/onewifi_pre_start.sh"  ${D}${systemd_unitdir}/system/onewifi.service
+        rm ${D}${systemd_unitdir}/system/ccspwifiagent.service
+   fi
+   sed -i "s/wan-initialized.target/multi-user.target/g" ${D}${systemd_unitdir}/system/rfc.service
+}
+
+
+SYSTEMD_SERVICE_${PN}_remove_onewifi = " ccspwifiagent.service"
+SYSTEMD_SERVICE_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'onewifi.service ', '', d)}"
+
+FILES_${PN}_remove_onewifi = "${systemd_unitdir}/system/ccspwifiagent.service"
+FILES_${PN}_append = "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' ${systemd_unitdir}/system/onewifi.service ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -1,0 +1,29 @@
+require ccsp_common_bananapi.inc
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+DEPENDS_remove = " opensync-2.4.1"
+DEPENDS_append = " opensync mesh-agent "
+
+CFLAGS_append = " -DWIFI_HAL_VERSION_3 -Wno-unused-function "
+LDFLAGS_append = " -ldl"
+CFLAGS_append_aarch64 = " -Wno-error "
+
+SRC_URI += " \
+    file://checkwifi.sh \
+    file://onewifi_pre_start.sh \
+    file://wifi_defaults.txt \
+"
+do_install_append(){
+    install -d ${D}/nvram 
+    install -m 777 ${WORKDIR}/checkwifi.sh ${D}/usr/ccsp/wifi/
+    install -m 777 ${WORKDIR}/onewifi_pre_start.sh ${D}/usr/ccsp/wifi/
+    install -m 644 ${WORKDIR}/wifi_defaults.txt ${D}/nvram/
+}
+
+FILES_${PN} += " \
+    ${prefix}/ccsp/wifi/checkwifi.sh \
+    ${prefix}/ccsp/wifi/onewifi_pre_start.sh \
+    /usr/bin/wifi_events_consumer \
+    /nvram/wifi_defaults.txt \
+"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-webui-jst.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-webui-jst.bbappend
@@ -1,0 +1,13 @@
+include ccsp_common_bananapi.inc
+
+do_install_append () {
+                if ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'true', 'false', d)}; then
+                   install -m 0755 ${S}/../xb6/jst/wireless_network_configuration_onewifi.jst ${D}/usr/www2/wireless_network_configuration.jst
+                   install -m 0755 ${S}/../xb6/jst/wireless_network_configuration_edit_onewifi.jst ${D}/usr/www2/wireless_network_configuration_edit.jst
+                   install -m 0755 ${S}/../xb6/jst/actionHandler/ajaxSet_wireless_network_configuration_onewifi.jst ${D}/usr/www2/actionHandler/ajaxSet_wireless_network_configuration.jst
+                   install -m 0755 ${S}/../xb6/jst/actionHandler/ajaxSet_wireless_network_configuration_edit_onewifi.jst ${D}/usr/www2/actionHandler/ajaxSet_wireless_network_configuration_edit.jst
+                   install -m 0755 ${S}/jst/actionHandler/ajaxSet_wireless_network_configuration_redirection_onewifi.jst ${D}/usr/www2/actionHandler/ajaxSet_wireless_network_configuration_redirection.jst
+                   install -m 0755 ${S}/jst/actionHandler/ajaxSet_wizard_step2_onewifi.jst ${D}/usr/www2/actionHandler/ajaxSet_wizard_step2.jst
+                   install -m 0755 ${S}/jst/actionHandler/ajaxSet_wps_config_onewifi.jst ${D}/usr/www2/actionHandler/ajaxSet_wps_config.jst
+                fi
+}

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/checkwifi.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/checkwifi.sh
@@ -1,0 +1,27 @@
+# If not stated otherwise in this file or this component's LICENSE
+# file the following copyright and licenses apply:
+#
+#Copyright [2024] [RDK Management]
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
+#!/bin/sh
+
+#checking wifi driver initialization 
+phy_index=`ls /sys/class/ieee80211/ | wc -l`
+
+if [ $phy_index != 0 ] ; then
+	touch /tmp/wifi_driver_initialized
+else
+	echo "Wifi driver is not initialized"
+fi

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+iw phy phy0 interface add wifi0 type __ap
+iw phy phy1 interface add wifi1 type __ap
+
+exit 0

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/wifi_defaults.txt
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/wifi_defaults.txt
@@ -1,0 +1,5 @@
+radius_s_port=8000
+radius_s_ip=127.0.0.1
+radius_key=1234567
+wps_pin=1234567
+bpi_wifi_password=rdk@1234

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-wifi-generic_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-wifi-generic_git.bbappend
@@ -1,0 +1,38 @@
+SRC_URI_append = " \
+    ${CMF_GIT_ROOT}/rdkb/devices/raspberrypi/hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};destsuffix=git/source/wifi/devices_bpi;name=wifihal-bananapi \
+"
+
+SRCREV_wifihal-bananapi = "${AUTOREV}"
+
+DEPENDS_append =" libev wpa-supplicant"
+DEPENDS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' rdk-wifi-hal', '', d)}"
+LDFLAGS_append = " -lev -lwpa_client -lpthread"
+
+do_configure_prepend(){
+    rm ${S}/wifi_hal.c
+    rm ${S}/Makefile.am
+    ln -sf ${S}/devices_bpi/source/wifi/wifi_hal.c ${S}/wifi_hal.c
+    ln -sf ${S}/devices_bpi/source/wifi/client_wifi_hal.c ${S}/client_wifi_hal.c
+    ln -sf ${S}/devices_bpi/source/wifi/wifi_hostapd_interface.c ${S}/wifi_hostapd_interface.c
+    ln -sf ${S}/devices_bpi/source/wifi/rpi_wifi_hal_assoc_devices_details.c ${S}/rpi_wifi_hal_assoc_devices_details.c
+    ln -sf ${S}/devices_bpi/source/wifi/rpi_wifi_hal_version_3.c ${S}/rpi_wifi_hal_version_3.c
+    ln -sf ${S}/devices_bpi/source/wifi/wifi_hal_rpi.h ${S}/wifi_hal_rpi.h
+    ln -sf ${S}/devices_bpi/source/wifi/Makefile.am ${S}/Makefile.am
+    sed -i "s/wlan0/wifi0/g" ${S}/wifi_hal.c
+    sed -i "s/wlan0/wifi0/g" ${S}/rpi_wifi_hal_assoc_devices_details.c
+    sed -i "s/wlan1/wifi1/g" ${S}/wifi_hal.c
+    sed -i "s/wlan1/wifi1/g" ${S}/rpi_wifi_hal_assoc_devices_details.c
+    sed -i "s/wlan%d/wifi%d/g" ${S}/wifi_hal.c
+    sed -i "s/wlan%d/wifi%d/g" ${S}/rpi_wifi_hal_assoc_devices_details.c
+}
+
+do_install_append(){
+    install -d ${D}/usr/bin
+    install -m 777 ${B}/wifihal ${D}/usr/bin/
+}
+
+CFLAGS_append = " -DWIFI_HAL_VERSION_3 "
+CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' -D_ONE_WIFI_ ', '', d)}"
+
+RDEPENDS_${PN} += "wpa-supplicant"
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/halinterface.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/halinterface.bbappend
@@ -1,0 +1,1 @@
+CFLAGS_append = " -DWIFI_HAL_VERSION_3"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,0 +1,4 @@
+CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT "
+CFLAGS_append_kirkstone = " -fcommon"
+EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' ONE_WIFIBUILD=true ', '', d)}"
+EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' BANANA_PI_PORT=true ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/Bpi_rdkwifilibhostap_changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/Bpi_rdkwifilibhostap_changes.patch
@@ -1,0 +1,25 @@
+--- git/source/hostap-2.10/src/ap/drv_callbacks.c	2023-06-08 11:27:27.645895606 +0000
++++ git/source/hostap-2.10/src/ap/drv_callbacks.c	2023-06-08 11:26:49.786465276 +0000
+@@ -772,6 +772,9 @@
+ 	wpa_auth_sm_event(sta->wpa_sm, WPA_DISASSOC);
+ 	sta->acct_terminate_cause = RADIUS_ACCT_TERMINATE_CAUSE_USER_REQUEST;
+ 	ieee802_1x_notify_port_enabled(sta->eapol_sm, 0);
++#ifdef _PLATFORM_BANANAPI_R4_
++	hostapd_drv_sta_disassoc(hapd, sta->addr, WLAN_REASON_DISASSOC_STA_HAS_LEFT);
++#endif	
+ 	ap_free_sta(hapd, sta);
+ }
+ 
+--- git/source/hostap-2.10/src/ap/hostapd.c	2023-06-10 18:14:04.381530228 +0000
++++ git/source/hostap-2.10/src/ap/hostapd.c	2023-06-10 18:14:25.597262764 +0000
+@@ -3321,6 +3321,10 @@
+ 	 * been authorized. */
+ 	if (!hapd->conf->ieee802_1x && !hapd->conf->wpa && !hapd->conf->osen) {
+ 		ap_sta_set_authorized(hapd, sta, 1);
++#ifdef _PLATFORM_BANANAPI_R4_
++		/*When Station is connected with OPEN Mode, need to authorize the station */
++		hostapd_set_authorized(hapd, sta, 1);
++#endif
+ 		os_get_reltime(&sta->connected_time);
+ 		accounting_sta_start(hapd, sta);
+ 	}

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " file://Bpi_rdkwifilibhostap_changes.patch "
+
+CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_"

--- a/meta-rdk-mtk-bpir4/recipes-common/mesh-agent/mesh-agent.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-common/mesh-agent/mesh-agent.bbappend
@@ -1,0 +1,1 @@
+CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_ "

--- a/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,0 +1,16 @@
+EXTRA_OEMAKE = "CONFIG_BUILD_WPA_CLIENT_SO=y"
+FILES_SOLIBSDEV = ""
+do_install_append () {
+	install -d ${D}${includedir}
+	install -d ${D}${libdir}
+	install -d ${D}/lib/rdk/
+
+	install -m 0777 ${S}/wpa_supplicant/libwpa_client.so  ${D}${libdir}/
+	install -m 0644 ${S}/src/common/wpa_ctrl.h ${D}${includedir}/
+}
+
+FILES_${PN} += "${libdir}/libwpa_client.so"
+FILES_${PN} += "${includedir}/wpa_ctrl.h"
+FILES_${PN} += "lib/rdk"
+FILES_${PN} += " /usr/local"
+FILES:${PN}-dbg += " /usr/local/"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
@@ -1,0 +1,5 @@
+RDEPENDS_packagegroup-filogic-mt76_remove_onewifi = " \
+                    hostapd \
+                    usteer \
+                    wifi-test-tool \
+"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
@@ -1,0 +1,2 @@
+RDEPENDS_packagegroup-rdk-ccsp-broadband_remove = " rdk-wifi-hal"
+RDEPENDS_packagegroup-rdk-ccsp-broadband_append = "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'rdk-wifi-hal', '' ,d)}"

--- a/meta-rdk-mtk-bpir4/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS:${PN}_remove = " gcc-plugins libmpc-dev"

--- a/meta-rdk-mtk-bpir4/recipes-opensync/opensync/files/updated_vendor_arch_to_support_bpi.patch
+++ b/meta-rdk-mtk-bpir4/recipes-opensync/opensync/files/updated_vendor_arch_to_support_bpi.patch
@@ -1,0 +1,13 @@
+Source: [PATCH] To add BananaPi rdk broadband target to avoid compilation issues
+
+--- a/build/vendor-arch.mk	2024-08-08 08:32:12.339200250 +0000
++++ b/build/vendor-arch.mk	2024-08-07 05:42:19.142119030 +0000
+@@ -14,7 +14,7 @@
+ #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ #See the License for the specific language governing permissions and
+ #limitations under the License.
+-RDK_TARGETS = RDKB raspberrypi4-rdk-broadband raspberrypi4-rdk-extender raspberrypi-rdk-broadband raspberrypi4-64-rdk-broadband
++RDK_TARGETS = RDKB raspberrypi4-rdk-broadband raspberrypi4-rdk-extender raspberrypi-rdk-broadband raspberrypi4-64-rdk-broadband bananapi4-rdk-broadband
+ 
+ ifneq ($(filter $(TARGET),$(RDK_TARGETS)),)
+ 

--- a/meta-rdk-mtk-bpir4/recipes-opensync/opensync/opensync_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-opensync/opensync/opensync_%.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+OPENSYNC_VENDOR_URI = "git://git@github.com/rdkcentral/opensync-vendor-rdk-rpi.git;protocol=${CMF_GIT_PROTOCOL};branch=main;name=vendor;destsuffix=git/vendor/rpi"
+OPENSYNC_VENDOR_URI += "file://updated_vendor_arch_to_support_bpi.patch;patchdir=../vendor/rpi"
+
+DEPENDS_append = " rdk-logger"
+
+
+do_compile_prepend_broadband(){
+	cd ${WORKDIR}/git/vendor/rpi/
+	rm -rf src
+	cd -
+}
+FILES_${PN} += "${includedir}/src"

--- a/meta-rdk-mtk-bpir4/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -1,4 +1,5 @@
 do_install_append () {
   #Webpa ServerURL
   echo "SERVERURL=http://webpa.rdkcentral.com:8080" >> ${D}${sysconfdir}/device.properties
+  ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'echo "OneWiFiEnabled=true" >> ${D}${sysconfdir}/device.properties', '', d)}
 }


### PR DESCRIPTION
Reason for change:  Added Onewifi integration in BPI R4 boards .
Test Procedure: wifi sanity 2g test cases are passed.
Risks: Low