### PR TITLE
RDKBACCL-293 : Telemetry 2.0 Integration in BPI reference platforms

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -20,16 +20,29 @@ do_install_append_class-target() {
    fi
    install -D -m 0644 ${S}/systemd_units/wan-initialized.target ${D}${systemd_unitdir}/system/wan-initialized.target
    install -D -m 0644 ${S}/systemd_units/wan-initialized.path ${D}${systemd_unitdir}/system/wan-initialized.path
+    #Telemetry support
+   install -D -m 0644 ${S}/systemd_units/CcspTelemetry.service ${D}${systemd_unitdir}/system/CcspTelemetry.service
+   sed -i "/Type=oneshot/a EnvironmentFile=\/etc/\device.properties" ${D}${systemd_unitdir}/system/CcspTelemetry.service
+   sed -i "/EnvironmentFile=\/etc\/device.properties/a EnvironmentFile=\/etc\/dcm.properties" ${D}${systemd_unitdir}/system/CcspTelemetry.service
+   sed -i "/EnvironmentFile=\/etc\/dcm.properties/a ExecStartPre=\/bin\/sh -c '\/bin\/touch \/rdklogs\/logs\/dcmscript.log'" ${D}${systemd_unitdir}/system/CcspTelemetry.service
+   sed -i "s/ExecStart=\/bin\/sh -c '\/lib\/rdk\/dcm.service \&'/ExecStart=\/bin\/sh -c '\/lib\/rdk\/StartDCM.sh \>\> \/rdklogs\/logs\/telemetry.log \&'/g" ${D}${systemd_unitdir}/system/CcspTelemetry.service
+   sed -i "s/wan-initialized.target/multi-user.target/g" ${D}${systemd_unitdir}/system/CcspTelemetry.service
+
+   install -D -m 0644 ${S}/systemd_units/notifyComp.service ${D}${systemd_unitdir}/system/notifyComp.service
 }
 
 
 SYSTEMD_SERVICE_${PN}_remove_onewifi = " ccspwifiagent.service"
 SYSTEMD_SERVICE_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'onewifi.service ', '', d)}"
 SYSTEMD_SERVICE_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'webconfig_bin', 'webconfig.service', '', d)}"
+SYSTEMD_SERVICE_${PN} += " CcspTelemetry.service"
+SYSTEMD_SERVICE_${PN} += " notifyComp.service"
 
 FILES_${PN}_remove_onewifi = "${systemd_unitdir}/system/ccspwifiagent.service"
 FILES_${PN}_append = "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' ${systemd_unitdir}/system/onewifi.service ', '', d)}"
 FILES_${PN}_append = " \
    ${systemd_unitdir}/system/wan-initialized.target \
    ${systemd_unitdir}/system/wan-initialized.path \
-      "
+   ${systemd_unitdir}/system/CcspTelemetry.service \
+   ${systemd_unitdir}/system/notifyComp.service \
+   "

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp_common_bananapi.inc
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp_common_bananapi.inc
@@ -1,0 +1,5 @@
+DEPENDS += "breakpad-wrapper"
+LDFLAGS += "-lbreakpadwrapper"
+
+LDFLAGS_append = " -lpthread -lcrypto"
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -13,4 +13,18 @@ mkdir -p \/etc\/dibbler \
 ln -s \/etc\/dibbler \/tmp \
 touch \/etc\/dibbler\/radvd.conf \
     fi
+
+#Adding telemetry defaults
+    echo "#UniqueTelemetryId default values
+\$unique_telemetry_enable=false
+\$unique_telemetry_tag=
+\$unique_telemetry_interval=0
+
+#TR181 Telemetry Support via MessageBusSource
+\$MessageBusSource=true
+
+#Defaults for Telemetry T2 Enable
+\$T2Enable=true
+\$T2Version=2.0.1
+\$T2ConfigURL=https://xconf.rdkcentral.com:19092/loguploader/getT2Settings"  >> ${D}${sysconfdir}/utopia/system_defaults
 }


### PR DESCRIPTION
Reason for change: Added Telemetry 2.0 support
Test Procedure: Test results are attached in JIRA
Risks: Low