### PR TITLE
RDKBACCL-426 : Parodus process is not running in bpi

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-support/parodus/parodus_1.0.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-support/parodus/parodus_1.0.bbappend
@@ -13,6 +13,7 @@ do_install_append () {
     install -d ${D}${base_libdir_native}/rdk
     install -m 0644 ${S}/devices/broadband/parodus/systemd/parodus.service ${D}${systemd_unitdir}/system
     install -m 0755 ${S}/devices/broadband/parodus/scripts/parodus_start.sh ${D}${base_libdir_native}/rdk
+    sed -i "s/eth0/lan0/g" ${D}${base_libdir_native}/rdk/parodus_start.sh
 }
 
 SYSTEMD_SERVICE_${PN}_append = " parodus.service"


### PR DESCRIPTION
Reason for change: Due to this, webpa functionality is breaking
Test Procedure: Webpa is working as expected
Risks: Low