### PR TITLE
RDKBACCL-435 : Latest BPI4 build is breaking due to latest import hal…

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-fwupgrade.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-fwupgrade.bbappend
@@ -1,0 +1,1 @@
+DEPENDS += " rdkb-halif-fwupgrade"


### PR DESCRIPTION
…interface change

Reason for change:  observing below errors,
./git/src/fwupgrade/fwupgrade_hal.c:30:10: fatal error: fwupgrade_hal.h: No such file or directory
|    30 | #include "fwupgrade_hal.h"
This issue is happening due to this gerrit changes (RDKB-56665)
Test Procedure: bitbake hal-fwupgrade
Risks: Low