### PR TITLE
Update packagegroup-rdk-ccsp-broadband.bbappend for GwProvApp 

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
@@ -1,2 +1,3 @@
 RDEPENDS_packagegroup-rdk-ccsp-broadband_remove = " rdk-wifi-hal"
 RDEPENDS_packagegroup-rdk-ccsp-broadband_append = "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'rdk-wifi-hal', '' ,d)}"
+GWPROVAPP = "${@bb.utils.contains('DISTRO_FEATURES','rdkb_wan_manager','ccsp-gwprovapp', '' ,d)}"


### PR DESCRIPTION
…

RDKBACCL-275 : Integrate the GwProvApp for the lan sysevents to be set properly during erouter0 interface bring up