### PR TITLE
RDKBACCL-446 : Latest BPI4 build is breaking due to recent changes in rdk-wifi-hal

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -2,8 +2,7 @@ require ccsp_common_bananapi.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-DEPENDS_remove = " opensync-2.4.1"
-DEPENDS_append = " opensync mesh-agent "
+DEPENDS_append = " mesh-agent "
 
 CFLAGS_append = " -DWIFI_HAL_VERSION_3 -Wno-unused-function "
 LDFLAGS_append = " -ldl"


### PR DESCRIPTION


Reason for change:  observing compilation issues with opensync and OneWifi.
Test Procedure: bitbake rdk-generic-broadband-image 
Risks: Low