### PR TITLE
RDKBACCL-316: cpuproc analyzer support in BPI R4

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -21,3 +21,5 @@ DISTRO_FEATURES_append = " acl_nl_support"
 DISTRO_FEATURES_append = " referencepltfm "
 
 MACHINEOVERRIDES_append =. "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ':onewifi', '' ,d)}"
+
+DISTRO_FEATURES_append = " CPUPROCANALYZER_BROADBAND"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
@@ -1,2 +1,6 @@
 RDEPENDS_packagegroup-rdk-ccsp-broadband_remove = " rdk-wifi-hal"
-RDEPENDS_packagegroup-rdk-ccsp-broadband_append = "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'rdk-wifi-hal', '' ,d)}"
+
+RDEPENDS_packagegroup-rdk-ccsp-broadband_append = " \
+           ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'rdk-wifi-hal', '' ,d)} \
+           ${@bb.utils.contains('DISTRO_FEATURES', 'CPUPROCANALYZER_BROADBAND', 'cpuprocanalyzer', ' ', d)} \
+           "

--- a/meta-rdk-mtk-bpir4/recipes-rdkb/sys_mon_tools/cpuprocanalyzer_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-rdkb/sys_mon_tools/cpuprocanalyzer_git.bbappend
@@ -1,0 +1,4 @@
+EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'CPUPROCANALYZER_BROADBAND', ' --enable-procanalyzer-broadband', '', d)}"
+DEPENDS += "telemetry json-c"
+ 
+CFLAGS_append = " -DPROCANALYZER_BROADBAND"


### PR DESCRIPTION
Reason for change: For supporting CPUProcAnalyzer in BPI & Enabling the Distro
Test Procedure: CpuProcAnalyzer should compile in build & functionality should work.
Risks: Low