### PR TITLE
Parse Error: Resolving below mentioned parse error in meta-cmf-banana…

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-platform-generic_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-platform-generic_git.bbappend
@@ -1,7 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_append += "file://Add_ipv6_changes.patch"
-=======
 do_configure_append() {
      #For trimming the spaces
      sed -i "s/cat \/proc\/device-tree\/model/cat \/proc\/device-tree\/model | tr -d ' '/g" ${S}/rdkb_hal/src/platform/platform_hal.c


### PR DESCRIPTION
…pi layer.

"ERROR: ParseError at /home/jenkins/jenkinsroot/workspace/Heam/SD_BPIR4/meta-cmf-bananapi/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-platform-generic_git.bbappend:4: unparsed line: '======='
 ERROR: Parsing halted due to errors, see error messages above "