### PR TITLE
RDKBACCL-450:webconfig.service auto start issue in BPIR4.

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -53,6 +53,8 @@ SYSTEMD_SERVICE_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'webconfig_bin
 SYSTEMD_SERVICE_${PN} += " CcspTelemetry.service"
 SYSTEMD_SERVICE_${PN} += " notifyComp.service"
 SYSTEMD_SERVICE_${PN} += "gwprovapp.service"
+SYSTEMD_SERVICE_${PN} += "wan-initialized.target"
+SYSTEMD_SERVICE_${PN} += "wan-initialized.path"
 SYSTEMD_SERVICE_${PN}_remove = " utopia.service"
 
 FILES_${PN}_remove_onewifi = "${systemd_unitdir}/system/ccspwifiagent.service"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
@@ -1221,4 +1221,6 @@
    <Record name="dmsb.wanmanager.if.1.VirtualInterface.1.Timeout" type="astr">20</Record> 
    <Record name="dmsb.wanmanager.if.1.VirtualInterface.1.VlanCount" type="astr">0</Record> 
    <Record name="dmsb.wanmanager.if.1.VirtualInterface.1.MarkingCount" type="astr">0</Record>
+   <!-- Webconfig.service auto start record -->
+   <Record name="eRT.com.cisco.spvtg.ccsp.webpa.WebConfigRfcEnable" type="astr">true</Record>
 </Provision>


### PR DESCRIPTION
Reason for change:Make webconfig service active when device boots up. 
Test Procedure:webconfig.service should be in active state when BPIR4 device boots up. 
Risks: Low