### PR TITLE
RDKBACCL-460 : Creating patches for onewifi bring up

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -1,6 +1,19 @@
 require ccsp_common_bananapi.inc
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:${THISDIR}/${PN}:"
+
+SRC_URI += " file://0001-RDKBACCL-403-RDKBDEV-2853-Bringup-onewifi-in-referen.patch;apply=no "
+
+do_bananapi_patches() {
+    cd ${S}
+    if [ ! -e bananapi_patch_applied ]; then
+        bbnote "Patching 0001-RDKBACCL-403-RDKBDEV-2853-Bringup-onewifi-in-referen.patch"
+        patch -p1 < ${WORKDIR}/0001-RDKBACCL-403-RDKBDEV-2853-Bringup-onewifi-in-referen.patch
+    touch bananapi_patch_applied
+    fi
+}
+
+addtask bananapi_patches after do_unpack before do_compile
 
 DEPENDS_append = " mesh-agent "
 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi/0001-RDKBACCL-403-RDKBDEV-2853-Bringup-onewifi-in-referen.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi/0001-RDKBACCL-403-RDKBDEV-2853-Bringup-onewifi-in-referen.patch
@@ -1,0 +1,40 @@
+From 1fcea51f89210e2efc8a4dd1cc1cc50e7d90cfa0 Mon Sep 17 00:00:00 2001
+From: "keerthana.p" <keerthana_pandurangan@comcast.com>
+Date: Fri, 16 Aug 2024 09:27:52 +0000
+Subject: [PATCH] RDKBACCL-403,RDKBDEV-2853 : Bringup onewifi in reference
+ platform of BPI R4
+
+Reason for change:  Added Onewifi integration with BPI flags to resolve
+issues .
+Test Procedure: wifi sanity test cases(2G) are passed.
+Risks: Low
+
+Change-Id: I761a03382ea67d76fc79a62052d36d975308f2f1
+Signed-off-by: keerthana.p <keerthana_pandurangan@comcast.com>
+---
+ source/core/wifi_easy_connect.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/source/core/wifi_easy_connect.c b/source/core/wifi_easy_connect.c
+index c05ad49..8b8bfde 100644
+--- a/source/core/wifi_easy_connect.c
++++ b/source/core/wifi_easy_connect.c
+@@ -50,7 +50,7 @@
+ #include "wifi_util.h"
+ 
+ #if !defined(_BWG_PRODUCT_REQ_)
+-#if !defined(_XF3_PRODUCT_REQ_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_) && !defined(_XB7_PRODUCT_REQ_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_XER5_PRODUCT_REQ_) && !defined(_SCER11BEL_PRODUCT_REQ_)
++#if !defined(_XF3_PRODUCT_REQ_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_) && !defined(_XB7_PRODUCT_REQ_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_XER5_PRODUCT_REQ_) && !defined(_SCER11BEL_PRODUCT_REQ_) && !defined(_PLATFORM_BANANAPI_R4_)
+ static const char *wifi_health_log = "/rdklogs/logs/wifihealth.txt";
+ 
+ extern bool is_device_associated(int ap_index, char *mac);
+@@ -851,5 +851,5 @@ get_easy_connect_best_enrollee_channels	(unsigned int ap_index)
+     return &g_easy_connect.channels_on_ap[ap_index];
+ }
+ 
+-#endif //#if !defined(_XF3_PRODUCT_REQ_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_) && !defined(_XB7_PRODUCT_REQ_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_XER5_PRODUCT_REQ_)  && !defined(_SCER11BEL_PRODUCT_REQ_)
++#endif //#if !defined(_XF3_PRODUCT_REQ_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_) && !defined(_XB7_PRODUCT_REQ_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_XER5_PRODUCT_REQ_)  && !defined(_SCER11BEL_PRODUCT_REQ_) && !defined(_PLATFORM_BANANAPI_R4_)
+ #endif //#if !defined(_BWG_PRODUCT_REQ_)
+-- 
+2.25.1
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/0001-RDKBACCL-404-RDKBDEV-2853-Bringup-onewifi-in-referen.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/0001-RDKBACCL-404-RDKBDEV-2853-Bringup-onewifi-in-referen.patch
@@ -1,0 +1,661 @@
+From dc7757a8592b03a4bd7bd67d778bd31c97db359a Mon Sep 17 00:00:00 2001
+From: "keerthana.p" <keerthana_pandurangan@comcast.com>
+Date: Fri, 16 Aug 2024 09:49:58 +0000
+Subject: [PATCH] RDKBACCL-404,RDKBDEV-2853 : Bringup onewifi in reference
+ platform of BPI R4
+
+Reason for change:  Added Onewifi integration with BPI flags to resolve
+issues .
+Test Procedure: wifi sanity test cases(2G) are passed.
+Risks: Low
+
+Change-Id: I90213717f2b61acfc4982d1f955cb3d04c5922be
+Signed-off-by: keerthana.p <keerthana_pandurangan@comcast.com>
+---
+ platform/banana-pi/platform.c | 308 ++++++++++++++++++++++++++++++++++
+ src/Makefile.am               |   5 +
+ src/configure.ac              |   1 +
+ src/wifi_hal.c                |  17 +-
+ src/wifi_hal_nl80211.c        |  18 +-
+ src/wifi_hal_nl80211_events.c |  14 +-
+ src/wifi_hal_nl80211_utils.c  |  55 ++++++
+ 7 files changed, 396 insertions(+), 22 deletions(-)
+ create mode 100644 platform/banana-pi/platform.c
+
+diff --git a/platform/banana-pi/platform.c b/platform/banana-pi/platform.c
+new file mode 100644
+index 0000000..6f22581
+--- /dev/null
++++ b/platform/banana-pi/platform.c
+@@ -0,0 +1,308 @@
++/************************************************************************
++* If not stated otherwise in this file or this component's Licenses.txt
++* file the following copyright and licenses apply:
++*
++* Copyright 2024 RDK Management
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++* http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++**************************************************************************/
++
++#include <stddef.h>
++#include <string.h>
++#include <stdlib.h>
++#include "wifi_hal_priv.h"
++#include "wifi_hal.h"
++
++#define NULL_CHAR '\0'
++#define NEW_LINE '\n'
++#define MAX_BUF_SIZE 128
++#define MAX_CMD_SIZE 1024
++#define BPI_LEN_32 32
++
++int wifi_nvram_defaultRead(char *in,char *out);
++int _syscmd(char *cmd, char *retBuf, int retBufSize);
++
++int wifi_nvram_defaultRead(char *in,char *out)
++{
++    char buf[MAX_BUF_SIZE]={'\0'};
++    char cmd[MAX_CMD_SIZE]={'\0'};
++    char *position;
++
++    sprintf(cmd,"grep '%s=' /nvram/wifi_defaults.txt",in);
++    if(_syscmd(cmd,buf,sizeof(buf)) == -1)
++    {
++        wifi_hal_dbg_print("\nError %d:%s:%s\n",__LINE__,__func__,__FILE__);
++        return -1;
++    }
++
++    if (buf[0] == NULL_CHAR)
++        return -1;
++    position = buf;
++    while(*position != NULL_CHAR)
++    {
++        if (*position == NEW_LINE)
++        {
++            *position = NULL_CHAR;
++            break;
++        }
++        position++;
++    }
++    position = strchr(buf, '=');
++    if (position == NULL)
++    {
++        wifi_hal_dbg_print("Line %d: invalid line '%s'",__LINE__, buf);
++        return -1;
++    }
++    *position = NULL_CHAR;
++    position++;
++    strncpy(out,position,strlen(position)+1);
++    return 0; 
++}
++
++int platform_pre_init()
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int platform_post_init(wifi_vap_info_map_t *vap_map)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    system("brctl addif brlan0 wifi0");
++    system("brctl addif brlan0 wifi1");
++    return 0;
++}
++
++
++int platform_set_radio(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int platform_set_radio_pre_init(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int platform_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
++{
++    char output_val[BPI_LEN_32];
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
++
++    if (map == NULL)
++    {
++        wifi_hal_dbg_print("%s:%d: wifi_vap_info_map_t *map is NULL \n", __func__, __LINE__);
++    }
++    for (index = 0; index < map->num_vaps; index++)
++    {
++      if (map->vap_array[index].vap_mode == wifi_vap_mode_ap)
++      {
++	//   Assigning default radius values 
++	    wifi_nvram_defaultRead("radius_s_port",output_val);
++	    map->vap_array[index].u.bss_info.security.u.radius.s_port = atoi(output_val);
++	    wifi_nvram_defaultRead("radius_s_ip",map->vap_array[index].u.bss_info.security.u.radius.s_ip);
++	    wifi_nvram_defaultRead("radius_key",map->vap_array[index].u.bss_info.security.u.radius.s_key);
++      }
++    } 
++    return 0;
++}
++
++int nvram_get_radio_enable_status(bool *radio_enable, int radio_index)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int nvram_get_vap_enable_status(bool *vap_enable, int vap_index)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int nvram_get_current_security_mode(wifi_security_modes_t *security_mode,int vap_index)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int platform_get_keypassphrase_default(char *password, int vap_index)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);  
++    /*password is not sensitive,won't grant access to real devices*/ 
++    wifi_nvram_defaultRead("bpi_wifi_password",password);
++    return 0;
++}
++
++int platform_get_ssid_default(char *ssid, int vap_index)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);   
++    sprintf(ssid,"BPI_RDKB-AP%d",vap_index);
++    return 0;
++}
++
++int platform_get_wps_pin_default(char *pin)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);  
++    wifi_nvram_defaultRead("wps_pin",pin);
++    return 0;
++}
++
++int platform_wps_event(wifi_wps_event_t data)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);  
++    return 0;
++}
++
++int platform_get_country_code_default(char *code)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);  
++    strcpy(code,"US");
++    return 0;
++}
++
++int nvram_get_current_password(char *l_password, int vap_index)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
++    /*password is not sensitive,won't grant access to real devices*/ 
++    wifi_nvram_defaultRead("bpi_wifi_password",l_password);
++    return 0;
++}
++
++int nvram_get_current_ssid(char *l_ssid, int vap_index)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__); 
++    sprintf(l_ssid,"BPI_RDKB-AP%d",vap_index);
++    return 0;
++}
++
++int platform_pre_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int platform_flags_init(int *flags)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
++    *flags = PLATFORM_FLAGS_STA_INACTIVITY_TIMER;
++    return 0;
++}
++
++int platform_get_aid(void* priv, u16* aid, const u8* addr)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int platform_free_aid(void* priv, u16* aid)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int platform_sync_done(void* priv)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int platform_get_channel_bandwidth(wifi_radio_index_t index,  wifi_channelBandwidth_t *channelWidth)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int platform_update_radio_presence(void)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int nvram_get_mgmt_frame_power_control(int vap_index, int* output_dbm)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
++    return 0;
++}
++
++int platform_set_txpower(void* priv, uint txpower)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
++    return 0;
++}
++
++int platform_set_offload_mode(void* priv, uint offload_mode)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
++    return RETURN_OK;
++}
++
++int platform_get_radius_key_default(char *radius_key)
++{
++    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
++    wifi_nvram_defaultRead("radius_key",radius_key);
++    return 0;	
++}
++
++int platform_get_acl_num(int vap_index, uint *acl_count)
++{
++    return 0;
++}
++
++int platform_get_vendor_oui(char *vendor_oui, int vendor_oui_len)
++{
++    return -1;
++}
++
++int platform_set_neighbor_report(uint index, uint add, mac_address_t mac)
++{
++    return 0;
++}
++
++int platform_get_radio_phytemperature(wifi_radio_index_t index,
++    wifi_radioTemperature_t *radioPhyTemperature)
++{
++    return 0;
++}
++
++int platform_set_dfs(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam)
++{
++    return 0;
++}
++
++int wifi_startNeighborScan(INT apIndex, wifi_neighborScanMode_t scan_mode, INT dwell_time, UINT chan_num, UINT *chan_list)
++{
++    return wifi_hal_startNeighborScan(apIndex, scan_mode, dwell_time, chan_num, chan_list);
++}
++
++int wifi_getNeighboringWiFiStatus(INT radio_index, wifi_neighbor_ap2_t **neighbor_ap_array, UINT *output_array_size)
++{
++    return wifi_hal_getNeighboringWiFiStatus(radio_index, neighbor_ap_array, output_array_size);
++}
++
++int wifi_setQamPlus(void *priv)
++{
++    return 0;
++}
++
++int wifi_setApRetrylimit(void *priv)
++{
++    return 0;
++}
++
++int platform_get_radio_caps(wifi_radio_index_t index)
++{
++    return 0;
++}
++
+diff --git a/src/Makefile.am b/src/Makefile.am
+index c1d54ac..0d45ed1 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -105,6 +105,11 @@ librdk_wifihal_la_CPPFLAGS += -I$(top_srcdir)/../platform/raspberry-pi
+ librdk_wifihal_la_SOURCES += ../platform/raspberry-pi/platform_pi.c
+ endif
+ 
++if BANANA_PI_PORT
++librdk_wifihal_la_CPPFLAGS += -I$(top_srcdir)/../platform/banana-pi
++librdk_wifihal_la_SOURCES += ../platform/banana-pi/platform.c
++endif
++
+ include_HEADERS = wifi_hal_rdk.h wifi_hal_rdk_framework.h ieee80211.h ../util_crypto/aes_siv.h
+ 
+ if ONE_WIFIBUILD
+diff --git a/src/configure.ac b/src/configure.ac
+index f1ca7d2..d77f55e 100644
+--- a/src/configure.ac
++++ b/src/configure.ac
+@@ -41,6 +41,7 @@ AC_ARG_ENABLE([gtestapp],
+ AM_CONDITIONAL([WITH_GTEST_SUPPORT], [test x$GTEST_SUPPORT_ENABLED = xtrue])
+ AM_CONDITIONAL([ONE_WIFIBUILD], [test "x$ONE_WIFIBUILD" = "xtrue"])
+ AM_CONDITIONAL([RASPBERRY_PI_PORT], [test "x$RASPBERRY_PI_PORT" = "xtrue"])
++AM_CONDITIONAL([BANANA_PI_PORT], [test "x$BANANA_PI_PORT" = "xtrue"])
+ AM_CONDITIONAL([TCXB7_PORT], [test "x$TCXB7_PORT" = "xtrue"])
+ AM_CONDITIONAL([VNTXER5_PORT], [test "x$VNTXER5_PORT" = "xtrue"])
+ AM_CONDITIONAL([TCHCBRV2_PORT], [test "x$TCHCBRV2_PORT" = "xtrue"])
+diff --git a/src/wifi_hal.c b/src/wifi_hal.c
+index b8eedc0..f9b6e06 100644
+--- a/src/wifi_hal.c
++++ b/src/wifi_hal.c
+@@ -704,12 +704,12 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
+         goto reload_config;
+     }
+ 
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+     // Call Vendor HAL
+     if (wifi_setRadioDfsAtBootUpEnable(index,operationParam->DfsEnabledBootup) != 0) {
+         wifi_hal_dbg_print("%s:%d:Failed to Enable DFSAtBootUp on radio %d\n", __func__, __LINE__, index);
+     }
+-#endif
++#endif // PLATFORM_RASPBERRYPI_ || _PLATFORM_BANANAPI_R4_
+ 
+ Exit:
+     if ((set_radio_params_fn = get_platform_set_radio_fn()) != NULL) {
+@@ -924,11 +924,11 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
+     platform_create_vap_t set_vap_params_fn;
+     unsigned int i;
+     char msg[2048];
+-#if defined(CMXB7_PORT) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined(CMXB7_PORT) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+     int set_acl = 0;
+ #else
+     int filtermode;
+-#endif // CMXB7_PORT || _PLATFORM_RASPBERRYPI_
++#endif // CMXB7_PORT || _PLATFORM_RASPBERRYPI_ || _PLATFORM_BANANAPI_R4_
+     //bssid_t null_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+ #if defined(VNTXER5_PORT)
+     char mld_ifname[32];
+@@ -990,13 +990,14 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
+             vap->u.bss_info.preassoc.minimum_advertised_mcs,
+             vap->u.bss_info.preassoc.sixGOpInfoMinRate);
+ 
+-#if defined(CMXB7_PORT) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined(CMXB7_PORT) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+         if ((vap->u.bss_info.enabled == 1) &&
+             ((vap->u.bss_info.mac_filter_enable == TRUE) ||
+              (interface->vap_info.u.bss_info.mac_filter_enable != vap->u.bss_info.mac_filter_enable))) {
+             set_acl = 1;
+         }
+-#endif
++#endif // PLATFORM_RASPBERRYPI_ || _PLATFORM_BANANAPI_R4_
++
+ #if defined(VNTXER5_PORT)
+         if (platform_set_intf_mld_bonding(radio, interface) != RETURN_OK) {
+             wifi_hal_error_print("%s:%d: vap index:%d failed to create bonding\n", __func__, __LINE__,
+@@ -1203,7 +1204,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
+         }
+ 
+         if (vap->vap_mode == wifi_vap_mode_ap) {
+-#if defined(CMXB7_PORT) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined(CMXB7_PORT) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+             if (set_acl == 1) {
+                 nl80211_set_acl(interface);
+             }
+@@ -1228,7 +1229,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
+                     __LINE__, vap->vap_index);
+                 return RETURN_ERR;
+             }
+-#endif // CMXB7_PORT || _PLATFORM_RASPBERRYPI_
++#endif // CMXB7_PORT || _PLATFORM_RASPBERRYPI_ || _PLATFORM_BANANAPI_R4_
+             re_configure_steering_mac_list(interface);
+         }
+         if (vap->vap_mode == wifi_vap_mode_ap) {
+diff --git a/src/wifi_hal_nl80211.c b/src/wifi_hal_nl80211.c
+index dc09bae..2575eeb 100644
+--- a/src/wifi_hal_nl80211.c
++++ b/src/wifi_hal_nl80211.c
+@@ -1433,7 +1433,7 @@ static void wifi_hal_steering_check_sta_status(wifi_interface_info_t *interface)
+             cli_cfg = &ptr->bm_client_cfg;
+             int32_t rssi_change_assoc = WIFI_STEERING_RSSI_UNCHANGED;
+             key = to_mac_str(ptr->mac_addr, sta_mac_str);
+-#if defined(CMXB7_PORT) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined(CMXB7_PORT) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+             wifi_associated_dev3_t associated_dev;
+             memset(&associated_dev, 0, sizeof(associated_dev));
+             //wifi_getApDeviceRSSI API is not available on CMXB7 platform. So, we need to use this API to get rssi value.
+@@ -1446,7 +1446,7 @@ static void wifi_hal_steering_check_sta_status(wifi_interface_info_t *interface)
+                 int snr = (rssi > -90) ? (rssi + 90) : 0;
+                 wifi_hal_dbg_print("old_snr::%d,New updated snr:%d for MAC=%s - vap:%d:: rssi:%d\n", ptr->rssi, snr, key, ptr->vap_index, rssi);
+                 ptr->rssi = snr;
+-#endif
++#endif // _PLATFORM_RASPBERRYPI_ || _PLATFORM_BANANAPI_R4_
+             }
+ 
+             wifi_hal_dbg_print("Check RSSI state for associated MAC=%s snr=%d hXing=%d, lXing=%d\n",
+@@ -2828,7 +2828,7 @@ int ovs_add_br(const char *brname)
+ {
+     wifi_hal_dbg_print("%s:%d ovs-vsctl add-br %s\n", __func__, __LINE__, brname);
+     int rc = run_prog("/usr/bin/ovs-vsctl",
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+                       "--may-exist",
+ #endif
+                       "add-br", brname);
+@@ -2879,7 +2879,7 @@ int ovs_br_add_if(const char *brname, const char *ifname)
+ {
+     wifi_hal_dbg_print("%s:%d ovs-vsctl add-port %s %s\n", __func__, __LINE__, brname, ifname);
+     int rc = run_prog("/usr/bin/ovs-vsctl",
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+                       "--may-exist",
+ #endif
+                       "add-port", brname, ifname);
+@@ -8880,7 +8880,7 @@ int wifi_drv_sta_disassoc(void *priv, const u8 *own_addr, const u8 *addr, u16 re
+ 
+     wifi_hal_dbg_print("%s:%d: Enter %s %d\n", __func__, __LINE__, to_mac_str(addr, mac_str), reason);
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+     wifi_device_callbacks_t *callbacks;
+ 
+     callbacks = get_hal_device_callbacks();
+@@ -8890,7 +8890,7 @@ int wifi_drv_sta_disassoc(void *priv, const u8 *own_addr, const u8 *addr, u16 re
+             callbacks->disassoc_cb[i](vap->vap_index, to_mac_str(addr, mac_str), 0);
+         }
+     }
+-#endif
++#endif // _PLATFORM_RASPBERRYPI_ || _PLATFORM_BANANAPI_R4_
+     if (drv->device_ap_sme) {
+         return wifi_sta_remove(interface, addr, 0, reason);
+     }
+@@ -10684,7 +10684,7 @@ int nl80211_set_acl_mode(wifi_interface_info_t *interface, uint32_t mac_filter_m
+     int ret = RETURN_OK;
+     wifi_vap_info_t *vap;
+     vap = &interface->vap_info;
+-#if defined(CMXB7_PORT) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined(CMXB7_PORT) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+     struct nl_msg *msg;
+     struct nlattr *acl;
+     unsigned int policy;
+@@ -10762,7 +10762,7 @@ int nl80211_set_acl_mode(wifi_interface_info_t *interface, uint32_t mac_filter_m
+             vap->u.bss_info.mac_filter_mode = mac_filter_mode;
+         }
+     }
+-#endif // CMXB7_PORT || _PLATFORM_RASPBERRYPI_
++#endif // CMXB7_PORT || _PLATFORM_RASPBERRYPI_ || _PLATFORM_BANANAPI_R4_
+     return ret;
+ }
+ 
+@@ -12087,7 +12087,7 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
+     msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_SET_KEY);
+ 
+     nla_put_u8(msg, NL80211_ATTR_KEY_IDX, params->key_idx);
+-#if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT) || defined (TCHCBRV2_PORT) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT) || defined (TCHCBRV2_PORT) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+     // NL80211_KEY_DEFAULT_BEACON enum is not defined in broadcom nl80211.h header
+     nla_put_flag(msg, wpa_alg_bip(params->alg) ? NL80211_ATTR_KEY_DEFAULT_MGMT : NL80211_ATTR_KEY_DEFAULT);
+ #else
+diff --git a/src/wifi_hal_nl80211_events.c b/src/wifi_hal_nl80211_events.c
+index 17b95c7..148f879 100644
+--- a/src/wifi_hal_nl80211_events.c
++++ b/src/wifi_hal_nl80211_events.c
+@@ -44,7 +44,7 @@ int no_seq_check(struct nl_msg *msg, void *arg)
+     return NL_OK;
+ }
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ static void nl80211_new_station_event(wifi_interface_info_t *interface, struct nlattr **tb)
+ {
+     union wpa_event_data event;
+@@ -81,7 +81,6 @@ static void nl80211_del_station_event(wifi_interface_info_t *interface, struct n
+     struct nlattr *attr;
+     mac_address_t mac;
+     mac_addr_str_t mac_str;
+-    char br_buff[128] = {0};
+ 
+     if ((attr = tb[NL80211_ATTR_MAC]) == NULL) {
+         wifi_hal_error_print("%s:%d: mac attribute not present ... dropping\n", __func__, __LINE__);
+@@ -91,13 +90,18 @@ static void nl80211_del_station_event(wifi_interface_info_t *interface, struct n
+     wifi_hal_error_print("%s:%d: DEL station:%s, sending event: EVENT_DISASSOC\n", __func__, __LINE__,
+         to_mac_str(mac, mac_str));
+ 
++#if defined(_PLATFORM_RASPBERRYPI_)
++    char br_buff[128] = {0};
+     snprintf(br_buff,sizeof(br_buff),"bridge fdb del %s dev %s master",to_mac_str(mac, mac_str),interface->name); //deleting fdb entries in bridge
+     system(br_buff);
++#endif
++
+     os_memset(&event, 0, sizeof(event));
+     event.disassoc_info.addr = mac;
+     wpa_supplicant_event(&interface->u.ap.hapd, EVENT_DISASSOC, &event);
+ }
+-#endif
++#endif //_PLATFORM_RASPBERRYPI_ || _PLATFORM_BANANAPI_R4_
++
+ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, struct nlattr **tb)
+ {
+     struct nlattr *frame, *addr, *cookie, *ack, *attr;
+@@ -1187,7 +1191,7 @@ static void nl80211_vendor_event(wifi_interface_info_t *interface,
+ static void do_process_drv_event(wifi_interface_info_t *interface, int cmd, struct nlattr **tb)
+ {
+     switch (cmd) {
+-#if defined(_PLATFORM_RASPBERRYPI_) 
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_) 
+     case NL80211_CMD_NEW_STATION:
+         nl80211_new_station_event(interface, tb);
+         break;
+@@ -1195,7 +1199,7 @@ static void do_process_drv_event(wifi_interface_info_t *interface, int cmd, stru
+     case NL80211_CMD_DEL_STATION:
+         nl80211_del_station_event(interface, tb);
+         break;
+-#endif
++#endif // _PLATFORM_RASPBERRYPI_ || _PLATFORM_BANANAPI_R4_
+     case NL80211_CMD_FRAME_TX_STATUS:
+         nl80211_frame_tx_status_event(interface, tb);
+         break;
+diff --git a/src/wifi_hal_nl80211_utils.c b/src/wifi_hal_nl80211_utils.c
+index 2fcb977..3cb43f7 100644
+--- a/src/wifi_hal_nl80211_utils.c
++++ b/src/wifi_hal_nl80211_utils.c
+@@ -58,6 +58,25 @@ wifi_interface_name_idex_map_t interface_index_map[] = {
+     {1, 1,  "wlan15",    "brlan2",    0,    15,     "mesh_sta_5g"},
+ #endif
+ 
++#ifdef BANANA_PI_PORT // for reference device platforms
++    {0, 0,  "wifi0",     "brlan0",    0,    0,      "private_ssid_2g"},
++    {1, 1,  "wifi1",     "brlan0",    0,    1,      "private_ssid_5g"},
++    {0, 0,  "wifi2",     "brlan1",    0,    2,      "iot_ssid_2g"},
++    {1, 1,  "wifi3",     "brlan1",    0,    3,      "iot_ssid_5g"},
++    {0, 0,  "wifi4",     "brlan2",    0,    4,      "hotspot_open_2g"},
++    {1, 1,  "wifi5",     "brlan3",    0,    5,      "hotspot_open_5g"},
++    {0, 0,  "wifi6",     "br1an4",    0,    6,      "lnf_psk_2g"},
++    {1, 1,  "wifi7",     "brlan3",    0,    7,      "lnf_psk_5g"},
++    {0, 0,  "wifi8",     "brlan4",    0,    8,      "hotspot_secure_2g"},
++    {1, 1,  "wifi9",     "brlan5",    0,    9,      "hotspot_secure_5g"},
++    {0, 0,  "wifi10",    "br1an6",    0,    10,     "lnf_radius_2g"},
++    {1, 1,  "wifi11",    "br1an6",    0,    11,     "lnf_radius_5g"},
++    {0, 0,  "wifi12",    "brlan2",    0,    12,     "mesh_backhaul_2g"},
++    {1, 1,  "wifi13",    "brlan3",    0,    13,     "mesh_backhaul_5g"},
++    {0, 0,  "wifi14",    "brlan2",    0,    14,     "mesh_sta_2g"},
++    {1, 1,  "wifi15",    "brlan2",    0,    15,     "mesh_sta_5g"},
++#endif
++
+ #ifdef TCXB7_PORT // for Broadcom based platforms
+     {0, 0,  "wl0.1",   "brlan0",  100,    0,      "private_ssid_2g"},
+     {1, 1,  "wl1.1",   "brlan0",  100,    1,      "private_ssid_5g"},
+@@ -329,6 +348,11 @@ static radio_interface_mapping_t l_radio_interface_map[] = {
+     { 0, 0, "radio1", "wlan0"},
+     { 1, 1, "radio2", "wlan1"},
+ #endif
++
++#ifdef BANANA_PI_PORT
++    { 0, 0, "radio1", "wifi0"},
++    { 1, 1, "radio2", "wifi1"},
++#endif
+ };
+ 
+ const wifi_driver_info_t  driver_info = {
+@@ -363,6 +387,37 @@ const wifi_driver_info_t  driver_info = {
+     platform_get_radio_caps,
+ #endif
+ 
++#ifdef BANANA_PI_PORT // for reference device platforms
++    "bpi4",
++    "cfg80211",
++    {"Banana Filogic Wireless Gateway","Banana","PI","PI","Model Description","Model URL","267","WPS Access Point","Manufacturer URL"},
++    platform_pre_init,
++    platform_post_init,
++    platform_set_radio,
++    platform_set_radio_pre_init,
++    platform_pre_create_vap,
++    platform_create_vap,
++    platform_get_ssid_default,
++    platform_get_keypassphrase_default,
++    platform_get_radius_key_default,
++    platform_get_wps_pin_default,
++    platform_get_country_code_default,
++    platform_wps_event,
++    platform_flags_init,
++    platform_get_aid,
++    platform_free_aid,
++    platform_sync_done,
++    platform_update_radio_presence,
++    platform_set_txpower,
++    platform_set_offload_mode,
++    platform_get_acl_num,
++    platform_get_vendor_oui,
++    platform_set_neighbor_report,
++    platform_get_radio_phytemperature,
++    platform_set_dfs,
++    platform_get_radio_caps,
++#endif
++
+ #ifdef TCXB7_PORT // for Broadcom based platforms
+     "tcxb7",
+     "dhd",
+-- 
+2.25.1
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,3 +1,19 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += " file://0001-RDKBACCL-404-RDKBDEV-2853-Bringup-onewifi-in-referen.patch;apply=no "
+
+do_bananapi_patches() {
+    cd ${S}
+    cd ..
+    if [ ! -e bananapi_patch_applied ]; then
+        bbnote "0001-RDKBACCL-404-RDKBDEV-2853-Bringup-onewifi-in-referen.patch"
+        patch -p1 < ${WORKDIR}//0001-RDKBACCL-404-RDKBDEV-2853-Bringup-onewifi-in-referen.patch
+    touch bananapi_patch_applied
+    fi
+}
+
+addtask bananapi_patches after do_unpack before do_compile
+
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT "
 CFLAGS_append_kirkstone = " -fcommon"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' ONE_WIFIBUILD=true ', '', d)}"


### PR DESCRIPTION
Reason for change:  Added Onewifi integration in BPI R4
Test Procedure: wifi sanity test cases(2G) are passed.
Risks: Low