### PR TITLE
RDKBACCL-471,RDKBACCL-470 : erouter0 is not getting ip addr intermittently

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -13,7 +13,7 @@ DISTRO_FEATURES_append = " halVersion3"
 DISTRO_FEATURES_append = " HOSTAPD_2_10"
 
 # OneWifi feature
-#DISTRO_FEATURES_append = " OneWifi"
+DISTRO_FEATURES_append = " OneWifi"
 
 # MacFilter Feature
 DISTRO_FEATURES_append = " acl_nl_support"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-adv-security.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-adv-security.bbappend
@@ -1,1 +1,15 @@
 include ccsp_common_bananapi.inc
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
+
+SRC_URI_append += " \
+    file://BPI-CcspAdvSecurity-changes.patch;apply=no \
+"
+do_bananapi_patches() {
+    cd ${S}
+    if [ ! -e bananapi_patch_applied ]; then
+        bbnote "Patching BPI-CcspAdvSecurity-changes.patch file"
+        patch -p1 < ${WORKDIR}/BPI-CcspAdvSecurity-changes.patch
+        touch bananapi_patch_applied
+    fi
+}
+addtask bananapi_patches after do_unpack before do_configure

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -36,6 +36,7 @@ do_install_append_class-target() {
    sed -i "/EnvironmentFile=\/etc\/dcm.properties/a ExecStartPre=\/bin\/sh -c '\/bin\/touch \/rdklogs\/logs\/dcmscript.log'" ${D}${systemd_unitdir}/system/CcspTelemetry.service
    sed -i "s/ExecStart=\/bin\/sh -c '\/lib\/rdk\/dcm.service \&'/ExecStart=\/bin\/sh -c '\/lib\/rdk\/StartDCM.sh \>\> \/rdklogs\/logs\/telemetry.log \&'/g" ${D}${systemd_unitdir}/system/CcspTelemetry.service
    sed -i "s/wan-initialized.target/multi-user.target/g" ${D}${systemd_unitdir}/system/CcspTelemetry.service
+   sed -i "s/wan-initialized.target/multi-user.target/g" ${D}${systemd_unitdir}/system/webconfig.service
 
    install -D -m 0644 ${S}/systemd_units/notifyComp.service ${D}${systemd_unitdir}/system/notifyComp.service
    install -D -m 0644 ${S}/systemd_units/gwprovapp.service ${D}${systemd_unitdir}/system/gwprovapp.service

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-dhcp-mgr.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-dhcp-mgr.bbappend
@@ -1,3 +1,16 @@
 include ccsp_common_bananapi.inc
-
 CFLAGS_append  = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '-DFEATURE_RDKB_WAN_MANAGER', '', d)}"
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
+
+SRC_URI_append += " \
+    file://BPI-DhcpManager-changes.patch;apply=no \
+"
+do_bananapi_patches() {
+    cd ${S}
+    if [ ! -e bananapi_patch_applied ]; then
+        bbnote "Patching BPI-DhcpManager-changes.patch file"
+        patch -p1 < ${WORKDIR}/BPI-DhcpManager-changes.patch
+        touch bananapi_patch_applied
+    fi
+}
+addtask bananapi_patches after do_unpack before do_configure

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
@@ -1,1 +1,13 @@
 include ccsp_common_bananapi.inc
+
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
+SRC_URI += " file://BPI-CcspEthAgent-changes.patch;apply=no "
+
+do_filogic_patches_append() {
+    cd ${S}
+    if [ ! -e bananapi_patch_applied ]; then
+        bbnote "Patching BPI-CcspEthAgent-changes.patch file"
+        patch -p1 < ${WORKDIR}/BPI-CcspEthAgent-changes.patch
+    touch bananapi_patch_applied
+    fi
+}

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-gwprovapp.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-gwprovapp.bbappend
@@ -1,6 +1,18 @@
 include ccsp_common_bananapi.inc
 export PLATFORM_BANANAPIR4_ENABLED="yes"
 
-FILES_${PN} += " \
-    /usr/bin/gw_prov_utopia \
+FILES_${PN} += "/usr/bin/gw_prov_utopia"
+
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
+SRC_URI_append += " \
+    file://BPI-GwProvApp-changes.patch;apply=no \
 "
+do_bananapi_patches() {
+    cd ${S}
+    if [ ! -e bananapi_patch_applied ]; then
+        bbnote "Patching BPI-GwProvApp-changes.patch file"
+        patch -p1 < ${WORKDIR}/BPI-GwProvApp-changes.patch
+        touch bananapi_patch_applied
+    fi
+}
+addtask bananapi_patches after do_unpack before do_configure

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-lm-lite.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-lm-lite.bbappend
@@ -1,1 +1,17 @@
 include ccsp_common_bananapi.inc
+
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
+
+SRC_URI_append += " \
+    file://BPI-CcspLMLite-changes.patch;apply=no \
+"
+do_bananapi_patches() {
+    cd ${S}
+
+    if [ ! -e bananapi_patch_applied ]; then
+        bbnote "Patching BPI-CcspLMLite-changes.patch file"
+        patch -p1 < ${WORKDIR}/BPI-CcspLMLite-changes.patch
+        touch bananapi_patch_applied
+    fi
+}
+addtask bananapi_patches after do_unpack before do_configure

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
@@ -1,1 +1,15 @@
 include ccsp_common_bananapi.inc
+
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
+SRC_URI_append += " \
+    file://BPI-CcspPandM-changes.patch;apply=no \
+"
+do_bananapi_patches() {
+    cd ${S}
+    if [ ! -e bananapi_patch_applied ]; then
+        bbnote "Patching BPI-CcspPandM-changes.patch file"
+        patch -p1 < ${WORKDIR}/BPI-CcspPandM-changes.patch
+        touch bananapi_patch_applied
+    fi
+}
+addtask bananapi_patches after do_unpack before do_configure

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-CcspAdvSecurity-changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-CcspAdvSecurity-changes.patch
@@ -1,0 +1,32 @@
+From 49cc24ad50be159b69b8cf463510c7f672086807 Mon Sep 17 00:00:00 2001
+From: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+Date: Tue, 13 Aug 2024 10:33:57 +0000
+Subject: [PATCH] RDKBACCL-275 :  Review generic rdk-b code and introduce
+ platform specific flags
+
+Reason for change : Changes for PandM
+Test Procedure: Build and flash the image.erouter0 should get ip
+Risks: None
+
+Change-Id: I5c025e1bd53a9633451dbce10fd6721b874c3990
+Signed-off-by: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+---
+ source/AdvSecurityDml/cosa_adv_security_internal.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/AdvSecurityDml/cosa_adv_security_internal.c b/source/AdvSecurityDml/cosa_adv_security_internal.c
+index da74bc8..aaf057c 100644
+--- a/source/AdvSecurityDml/cosa_adv_security_internal.c
++++ b/source/AdvSecurityDml/cosa_adv_security_internal.c
+@@ -101,7 +101,7 @@
+ 
+ #define NUM_SYSEVENT_TYPES (sizeof(advSysEvent_type_table)/sizeof(advSysEvent_type_table[0]))
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_XER5_PRODUCT_REQ_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_XER5_PRODUCT_REQ_) || defined(_PLATFORM_BANANAPI_R4_)
+ #include "ccsp_vendor.h"
+ #endif
+ 
+-- 
+2.47.0
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-CcspEthAgent-changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-CcspEthAgent-changes.patch
@@ -1,0 +1,221 @@
+From 9080b2f64de78f7f4e0c54090ec1b09c58889c51 Mon Sep 17 00:00:00 2001
+From: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+Date: Wed, 9 Oct 2024 15:09:47 +0000
+Subject: [PATCH] RDKBACCL-275 :  Review generic rdk-b code and introduce
+ platform specific flags
+
+Reason for change : Changes for Ethagent for BananaPi R4
+Test Procedure: Build and flash the image.erouter0 should get ip
+Risks: None
+
+Change-Id: Ib70edb5ff889df18a21ae70535d37154f088da23
+Signed-off-by: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+---
+ source/EthSsp/ssp_main.c                      |  2 +-
+ .../TR-181/board_sbapi/cosa_ethernet_apis.c   | 29 ++++++++++++++++---
+ .../board_sbapi/cosa_ethernet_manager.c       |  2 +-
+ .../middle_layer_src/cosa_ethernet_internal.c |  4 +--
+ .../middle_layer_src/cosa_rbus_handler_apis.c |  6 ++--
+ .../middle_layer_src/cosa_rbus_handler_apis.h |  4 +--
+ .../middle_layer_src/plugin_main_apis.c       |  2 +-
+ 7 files changed, 35 insertions(+), 14 deletions(-)
+
+diff --git a/source/EthSsp/ssp_main.c b/source/EthSsp/ssp_main.c
+index 24b265e..d2fdf66 100644
+--- a/source/EthSsp/ssp_main.c
++++ b/source/EthSsp/ssp_main.c
+@@ -52,7 +52,7 @@
+ #include <syscfg/syscfg.h>
+ #include "cap.h"
+ #include "safec_lib_common.h"
+-#if defined(_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ #include "cosa_rbus_handler_apis.h"
+ #include "cosa_apis_util.h"
+ #endif
+diff --git a/source/TR-181/board_sbapi/cosa_ethernet_apis.c b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+index b6fa3bb..00027f6 100755
+--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
++++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+@@ -586,6 +586,8 @@ COSA_DML_IF_STATUS getIfStatus(const PUCHAR name, struct ifreq *pIfr)
+ #define ETHWAN_DEF_INTF_NAME "nsgmii0"
+ #elif defined (_PLATFORM_TURRIS_)
+ #define ETHWAN_DEF_INTF_NAME "eth2"
++#elif defined (_PLATFORM_BANANAPI_R4_)
++#define ETHWAN_DEF_INTF_NAME "lan0"
+ #else
+ #define ETHWAN_DEF_INTF_NAME "eth0"
+ #endif
+@@ -2751,7 +2753,8 @@ CosaDmlEthInit(
+         }
+     }
+ #else
+-    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)
++    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
++
+     char wanPhyName[20] = {0},out_value[20] = {0};
+ 
+     if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
+@@ -2942,7 +2945,11 @@ CosaDmlEthPortInit(
+         pETHlinkTemp[iLoopCount].LinkStatus = ETH_LINK_STATUS_DOWN;
+         pETHlinkTemp[iLoopCount].ulInstanceNumber = iLoopCount + 1;
+         // Get  Name.
+-        snprintf(pETHlinkTemp[iLoopCount].Name, sizeof(pETHlinkTemp[iLoopCount].Name), "eth%d", iLoopCount);
++	#if defined (_PLATFORM_BANANAPI_R4_)
++		snprintf(pETHlinkTemp[iLoopCount].Name, sizeof(pETHlinkTemp[iLoopCount].Name), "lan%d", iLoopCount);
++	#else	
++                snprintf(pETHlinkTemp[iLoopCount].Name, sizeof(pETHlinkTemp[iLoopCount].Name), "eth%d", iLoopCount);
++	#endif		
+         snprintf(pETHlinkTemp[iLoopCount].Path, sizeof(pETHlinkTemp[iLoopCount].Path), "%s%d", ETHERNET_IF_PATH, iLoopCount + 1);
+         pETHlinkTemp[iLoopCount].Upstream = FALSE;
+         pETHlinkTemp[iLoopCount].WanValidated = FALSE;
+@@ -3022,6 +3029,9 @@ CosaDmlEthPortInit(
+                 snprintf(pETHTemp->Name, sizeof(pETHTemp->Name), "sw_%d", iLoopCount + 1);
+             }
+             CcspTraceWarning(("\n ifname copied %s index %d\n",pETHTemp->Name,iLoopCount));
++#elif defined (_PLATFORM_BANANAPI_R4_)	    
++
++	    snprintf(pETHTemp->Name, sizeof(pETHTemp->Name), "lan%d", iLoopCount);
+ #else
+             // Generate Name.
+             snprintf(pETHTemp->Name, sizeof(pETHTemp->Name), "eth%d", iLoopCount);
+@@ -3118,7 +3128,11 @@ ANSC_STATUS CosDmlEthPortUpdateGlobalInfo(PANSC_HANDLE phContext, char *ifname,
+         gpstEthGInfo[newIndex].LinkStatus = ETH_LINK_STATUS_DOWN;
+         gpstEthGInfo[newIndex].WanValidated = TRUE; //Make default as True.
+         gpstEthGInfo[newIndex].Enable = FALSE; //Make default as False.
+-        snprintf(gpstEthGInfo[newIndex].Name, sizeof(gpstEthGInfo[newIndex].Name), "eth%d", newIndex);
++        #if defined(_PLATFORM_BANANAPI_R4_)
++		snprintf(gpstEthGInfo[newIndex].Name, sizeof(gpstEthGInfo[newIndex].Name), "lan%d", newIndex);
++        #else	
++        	snprintf(gpstEthGInfo[newIndex].Name, sizeof(gpstEthGInfo[newIndex].Name), "eth%d", newIndex);
++	#endif		
+         snprintf(gpstEthGInfo[newIndex].Path, sizeof(gpstEthGInfo[newIndex].Path), "%s%d", ETHERNET_IF_PATH, newIndex + 1 );
+         snprintf(gpstEthGInfo[newIndex].LowerLayers, sizeof(gpstEthGInfo[newIndex].LowerLayers), "%s%d", ETHERNET_IF_LOWERLAYERS, newIndex + 1 );
+         pthread_mutex_unlock(&gmEthGInfo_mutex);
+@@ -3256,7 +3270,12 @@ ANSC_STATUS CosaDmlEthGetPortCfg(INT nIndex, PCOSA_DML_ETH_PORT_CONFIG pEthLink)
+         pEthLink->WanStatus = wan_status;
+     }
+ 
+-    snprintf(pEthLink->Name, sizeof(pEthLink->Name), "eth%d", nIndex);
++#if defined(_PLATFORM_BANANAPI_R4_)
++    	 snprintf(pEthLink->Name, sizeof(pEthLink->Name), "lan%d", nIndex);
++#else	 
++
++    	 snprintf(pEthLink->Name, sizeof(pEthLink->Name), "eth%d", nIndex);
++#endif	 
+ #else
+     UNREFERENCED_PARAMETER(nIndex);
+     UNREFERENCED_PARAMETER(pEthLink);
+@@ -3724,6 +3743,8 @@ static ANSC_STATUS CosDmlEthPortPrepareGlobalInfo()
+                 snprintf(gpstEthGInfo[iLoopCount].Name, sizeof(gpstEthGInfo[iLoopCount].Name), "sw_%d", iLoopCount+1);
+             }
+             CcspTraceWarning(("\n ifname copied %s index %d\n",gpstEthGInfo[iLoopCount].Name,iLoopCount));
++#elif defined (_PLATFORM_BANANAPI_R4_)
++	    snprintf(gpstEthGInfo[iLoopCount].Name, sizeof(gpstEthGInfo[iLoopCount].Name), "lan%d", iLoopCount);
+ #else
+             snprintf(gpstEthGInfo[iLoopCount].Name, sizeof(gpstEthGInfo[iLoopCount].Name), "eth%d", iLoopCount);
+ #endif
+diff --git a/source/TR-181/board_sbapi/cosa_ethernet_manager.c b/source/TR-181/board_sbapi/cosa_ethernet_manager.c
+index 7274316..fe97d7f 100644
+--- a/source/TR-181/board_sbapi/cosa_ethernet_manager.c
++++ b/source/TR-181/board_sbapi/cosa_ethernet_manager.c
+@@ -375,7 +375,7 @@ static ethSmState_t Transition_EthWanLinkFound(PETH_SM_PRIVATE_INFO pstInfo)
+ #if defined(FEATURE_RDKB_WAN_AGENT)
+     if (ANSC_STATUS_SUCCESS != CosaDmlEthCreateEthLink(pstInfo->Name, stGlobalInfo.Path))
+ #elif defined(FEATURE_RDKB_WAN_MANAGER)
+-    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)    
++    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+     CHAR wanPhyName[20] = {0},out_value[20] = {0};
+     if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
+     {
+diff --git a/source/TR-181/middle_layer_src/cosa_ethernet_internal.c b/source/TR-181/middle_layer_src/cosa_ethernet_internal.c
+index e9ea8ad..9adef2b 100644
+--- a/source/TR-181/middle_layer_src/cosa_ethernet_internal.c
++++ b/source/TR-181/middle_layer_src/cosa_ethernet_internal.c
+@@ -83,7 +83,7 @@
+ #endif
+ #endif //#if defined (FEATURE_RDKB_WAN_MANAGER)
+ 
+-#if defined (WAN_FAILOVER_SUPPORTED)  ||  defined(RBUS_BUILD_FLAG_ENABLE) || defined (_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (WAN_FAILOVER_SUPPORTED)  ||  defined(RBUS_BUILD_FLAG_ENABLE) || defined (_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ #include "cosa_rbus_handler_apis.h"
+ #endif
+ 
+@@ -370,7 +370,7 @@ CosaEthernetInitialize
+ 
+ #if defined(FEATURE_RDKB_WAN_MANAGER)
+ 
+-#if defined (WAN_FAILOVER_SUPPORTED) || defined(RBUS_BUILD_FLAG_ENABLE) || defined (_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (WAN_FAILOVER_SUPPORTED) || defined(RBUS_BUILD_FLAG_ENABLE) || defined (_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ 	ethAgentRbusInit();
+ #endif
+ 
+diff --git a/source/TR-181/middle_layer_src/cosa_rbus_handler_apis.c b/source/TR-181/middle_layer_src/cosa_rbus_handler_apis.c
+index d592618..b26c67b 100644
+--- a/source/TR-181/middle_layer_src/cosa_rbus_handler_apis.c
++++ b/source/TR-181/middle_layer_src/cosa_rbus_handler_apis.c
+@@ -23,7 +23,7 @@
+ #include "ccsp_trace.h"
+ #include "cosa_rbus_handler_apis.h"
+ 
+-#if  defined  (WAN_FAILOVER_SUPPORTED) ||  defined(RBUS_BUILD_FLAG_ENABLE) || defined (_HUB4_PRODUCT_REQ_) || defined (_PLATFORM_RASPBERRYPI_)
++#if  defined  (WAN_FAILOVER_SUPPORTED) ||  defined(RBUS_BUILD_FLAG_ENABLE) || defined (_HUB4_PRODUCT_REQ_) || defined (_PLATFORM_RASPBERRYPI_) ||  defined(_PLATFORM_BANANAPI_R4_)
+ rbusHandle_t handle;
+ #endif
+ 
+@@ -187,7 +187,7 @@ void publishEWanLinkStatus(bool link_status)
+ }
+ #endif //WAN_FAILOVER_SUPPORTED
+ 
+-#if defined (_HUB4_PRODUCT_REQ_) || defined (_PLATFORM_RASPBERRYPI_)
++#if defined (_HUB4_PRODUCT_REQ_) || defined (_PLATFORM_RASPBERRYPI_) ||  defined(_PLATFORM_BANANAPI_R4_)
+ BOOL EthAgent_Rbus_discover_components(char const *pModuleList)
+ {
+     rbusError_t rc = RBUS_ERROR_SUCCESS;
+@@ -245,7 +245,7 @@ BOOL EthAgent_Rbus_discover_components(char const *pModuleList)
+ 
+ #endif //_HUB4_PRODUCT_REQ_
+ 
+-#if  defined  (WAN_FAILOVER_SUPPORTED) ||  defined(RBUS_BUILD_FLAG_ENABLE) || defined (_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if  defined  (WAN_FAILOVER_SUPPORTED) ||  defined(RBUS_BUILD_FLAG_ENABLE) || defined (_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) ||  defined(_PLATFORM_BANANAPI_R4_)
+ /***********************************************************************
+ 
+   ethAgentRbusInit(): Initialize Rbus and data elements
+diff --git a/source/TR-181/middle_layer_src/cosa_rbus_handler_apis.h b/source/TR-181/middle_layer_src/cosa_rbus_handler_apis.h
+index 1e1257a..35b89fa 100644
+--- a/source/TR-181/middle_layer_src/cosa_rbus_handler_apis.h
++++ b/source/TR-181/middle_layer_src/cosa_rbus_handler_apis.h
+@@ -20,7 +20,7 @@
+ #ifndef  RBUS_HANDLER_APIS_H
+ #define  RBUS_HANDLER_APIS_H
+ 
+-#if defined (WAN_FAILOVER_SUPPORTED) ||  defined(RBUS_BUILD_FLAG_ENABLE) || defined (_HUB4_PRODUCT_REQ_) || defined (_PLATFORM_RASPBERRYPI_)
++#if defined (WAN_FAILOVER_SUPPORTED) ||  defined(RBUS_BUILD_FLAG_ENABLE) || defined (_HUB4_PRODUCT_REQ_) || defined (_PLATFORM_RASPBERRYPI_) ||  defined(_PLATFORM_BANANAPI_R4_)
+ #include <stdbool.h>
+ #include <rbus/rbus.h>
+ 
+@@ -49,7 +49,7 @@ void publishEWanLinkStatus(bool link_status);
+ 
+ #endif //WAN_FAILOVER_SUPPORTED
+ rbusError_t ethAgentRbusInit();
+-#if defined (_HUB4_PRODUCT_REQ_) || defined (_PLATFORM_RASPBERRYPI_)
++#if defined (_HUB4_PRODUCT_REQ_) || defined (_PLATFORM_RASPBERRYPI_) ||  defined(_PLATFORM_BANANAPI_R4_)
+ BOOL EthAgent_Rbus_discover_components(char const *pModuleList);
+ #endif //_HUB4_PRODUCT_REQ_
+ #endif // WAN_FAILOVER_SUPPORTED RBUS_BUILD_FLAG_ENABLE _HUB4_PRODUCT_REQ_
+diff --git a/source/TR-181/middle_layer_src/plugin_main_apis.c b/source/TR-181/middle_layer_src/plugin_main_apis.c
+index 2dc30da..9961260 100644
+--- a/source/TR-181/middle_layer_src/plugin_main_apis.c
++++ b/source/TR-181/middle_layer_src/plugin_main_apis.c
+@@ -73,7 +73,7 @@
+ #include "cosa_common_util.h"
+ #endif
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ extern int sock;
+ #endif
+ 
+-- 
+2.47.0
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-CcspLMLite-changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-CcspLMLite-changes.patch
@@ -1,0 +1,32 @@
+From 04e7e0b27f636fb1a74bc2c205df0a4d65f75c39 Mon Sep 17 00:00:00 2001
+From: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+Date: Wed, 14 Aug 2024 07:22:25 +0000
+Subject: [PATCH] RDKBACCL-275 :  Review generic rdk-b code and introduce
+ platform specific flags
+
+Reason for change : Changes for PandM
+Test Procedure: Build and flash the image.erouter0 should get ip
+Risks: None
+
+Change-Id: I3273cc719b58c12cc85755810ac68ee7148994d6
+Signed-off-by: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+---
+ source/lm/lm_main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/lm/lm_main.c b/source/lm/lm_main.c
+index f3b3093..a007d3e 100644
+--- a/source/lm/lm_main.c
++++ b/source/lm/lm_main.c
+@@ -2726,7 +2726,7 @@ static void *Hosts_StatSyncThreadFunc(void *args)
+         }
+         else
+         {
+-#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_)
+             if(bridgemode)
+             {
+                 Send_Eth_Host_Sync_Req(); 
+-- 
+2.47.0
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-CcspPandM-changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-CcspPandM-changes.patch
@@ -1,0 +1,290 @@
+From c1b427719825394547806d0bc091687df9bccc8d Mon Sep 17 00:00:00 2001
+From: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+Date: Wed, 9 Oct 2024 09:47:03 +0000
+Subject: [PATCH] RDKBACCL-275 :  Review generic rdk-b code and introduce
+ platform specific flags
+
+Reason for change : Changes for PandM for BananaPiR4
+Test Procedure: Build and flash the image.erouter0 should get ip
+Risks: None
+
+Change-Id: I12705a7bb377bd390aa8ffff265e88c92ffa2ea8
+---
+ .../custom_ml/cosa_deviceinfo_dml_custom.c     |  6 +++---
+ .../TR-181/board_sbapi/cosa_deviceinfo_apis.c  | 12 +++++++++---
+ source-arm/TR-181/board_sbapi/cosa_ip_apis.c   |  2 ++
+ .../TR-181/board_sbapi/cosa_users_apis.c       |  4 ++--
+ source/PandMSsp/ssp_main.c                     |  8 ++++----
+ .../middle_layer_src/cosa_deviceinfo_dml.c     | 18 +++++++++---------
+ .../middle_layer_src/cosa_users_internal.c     |  2 +-
+ .../cosa_x_cisco_com_devicecontrol_dml.c       |  2 +-
+ 8 files changed, 31 insertions(+), 23 deletions(-)
+
+diff --git a/custom/comcast/source/TR-181/custom_ml/cosa_deviceinfo_dml_custom.c b/custom/comcast/source/TR-181/custom_ml/cosa_deviceinfo_dml_custom.c
+index 2504dd67..88e337b1 100644
+--- a/custom/comcast/source/TR-181/custom_ml/cosa_deviceinfo_dml_custom.c
++++ b/custom/comcast/source/TR-181/custom_ml/cosa_deviceinfo_dml_custom.c
+@@ -340,7 +340,7 @@ DeviceInfo_GetParamStringValue_Custom
+ 
+ 	if (strcmp(ParamName, "X_COMCAST-COM_MTA_MAC") == 0)
+ 	{
+-#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_)
+   	   CosaDmlDiGetMTAMacAddress(NULL, pValue,pulSize);
+ #endif
+ 	   return 0;
+@@ -383,7 +383,7 @@ DeviceInfo_GetParamStringValue_Custom
+ 
+ 	if (strcmp(ParamName, "X_COMCAST-COM_MTA_IP") == 0)
+ 	{
+-#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_)
+    	   CosaDmlDiGetMTAIPAddress(NULL, pValue,pulSize);
+ #endif
+ 	   return 0;
+@@ -391,7 +391,7 @@ DeviceInfo_GetParamStringValue_Custom
+ 
+ 	if (strcmp(ParamName, "X_COMCAST-COM_MTA_IPV6") == 0)
+ 	{
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+    	   CosaDmlDiGetMTAIPV6Address(NULL, pValue,pulSize);
+ #endif
+ 	   return 0;
+diff --git a/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c b/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c
+index a02a4fd6..e99079a8 100644
+--- a/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c
++++ b/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c
+@@ -123,6 +123,12 @@ static int writeToJson(char *data, char *file);
+ #include "ccsp_vendor.h"
+ #endif
+ 
++#ifdef _PLATFORM_BANANAPI_R4_
++#include "ccsp_vendor.h"
++#endif
++
++
++
+ #ifdef _COSA_SIM_
+ 
+ #elif defined(_COSA_INTEL_USG_ARM_) || defined(_COSA_BCM_ARM_) || defined(_COSA_BCM_MIPS_) || defined(_PLATFORM_IPQ_) || defined(_XER5_PRODUCT_REQ_)
+@@ -1351,7 +1357,7 @@ isValidInput
+   return returnStatus;
+ }
+ /* Maitenance window can be customized for bci routers */
+-#if defined(_COSA_BCM_MIPS_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_COSA_BCM_MIPS_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ ANSC_STATUS
+ CosaDmlDiGetFirmwareUpgradeStartTime
+     (
+@@ -1441,7 +1447,7 @@ CosaDmlDiGetFirmwareUpgradeStartTime
+ }
+ #endif
+ 
+-#if defined(_COSA_BCM_MIPS_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_COSA_BCM_MIPS_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ ANSC_STATUS
+ CosaDmlDiGetFirmwareUpgradeEndTime
+     (
+@@ -4003,7 +4009,7 @@ void FillPartnerIDValues(cJSON *json , char *partnerID , PCOSA_DATAMODEL_RDKB_UI
+ 					v_secure_system("sh /lib/rdk/wan_ssh.sh disable &");
+ 				}
+ 
+-#if defined(_COSA_BCM_ARM_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_ENABLE_DSL_SUPPORT_)
++#if defined(_COSA_BCM_ARM_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_ENABLE_DSL_SUPPORT_) && !defined(_PLATFORM_BANANAPI_R4_)
+                                 paramObjVal = cJSON_GetObjectItem(cJSON_GetObjectItem( partnerObj, "Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.CMVoiceImageSelect"), "ActiveValue");
+                                 if ( paramObjVal != NULL )
+                                 {
+diff --git a/source-arm/TR-181/board_sbapi/cosa_ip_apis.c b/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
+index b4669693..0a92b26b 100644
+--- a/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
++++ b/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
+@@ -337,10 +337,12 @@ static USG_IF_CFG_T g_usg_if_cfg[] =
+ #if defined(_COSA_INTEL_USG_ARM_) && !defined(_ENABLE_DSL_SUPPORT_)
+ #ifndef _PLATFORM_RASPBERRYPI_
+ #ifndef _PLATFORM_TURRIS_
++#ifndef _PLATFORM_BANANAPI_R4_    
+     {"wan0",        COSA_DML_LINK_TYPE_DOCSIS,  TRUE},  /*DH  wan0 should never appear here -- CM extensions are for DOCSIS interfaces */
+ #endif
+ #endif
+ #endif
++#endif      
+     {"lo",          COSA_DML_LINK_TYPE_EthLink, FALSE}, /*DH  change the value of gDmsbIpIfLoopbackInstNum too, if "lo" is moved to a different location */
+     /*
+      *  Multi-LAN -- still have to keep primary LAN interface for IPv6 settings -- overlapping with MLAN configuration
+diff --git a/source-arm/TR-181/board_sbapi/cosa_users_apis.c b/source-arm/TR-181/board_sbapi/cosa_users_apis.c
+index 01bb7cfd..4f29e592 100644
+--- a/source-arm/TR-181/board_sbapi/cosa_users_apis.c
++++ b/source-arm/TR-181/board_sbapi/cosa_users_apis.c
+@@ -570,7 +570,7 @@ user_validatepwd
+ 
+    if(fromDB[0] == '\0')
+    {
+-#if defined(_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)
++#if defined(_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+          user_hashandsavepwd(hContext,pEntry->Password,pEntry);
+ #else
+          FILE *fptr;
+@@ -719,7 +719,7 @@ CosaDmlUserResetPassword
+ 
+    if(!strcmp(pEntry->Username,"admin"))
+    {
+-#if defined(_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)
++#if defined(_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)  || defined(_PLATFORM_BANANAPI_R4_)
+          //TODO: Avoid the hardcoded password.        
+          errno_t safec_rc = -1;
+          safec_rc = strcpy_s(defPassword,sizeof(defPassword),"password");
+diff --git a/source/PandMSsp/ssp_main.c b/source/PandMSsp/ssp_main.c
+index 03e3fc0f..e6653587 100644
+--- a/source/PandMSsp/ssp_main.c
++++ b/source/PandMSsp/ssp_main.c
+@@ -59,7 +59,7 @@
+ #include <semaphore.h>
+ #include <fcntl.h>
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ #include <stdio.h>
+ #include <sys/socket.h>
+ #include <stdlib.h>
+@@ -477,7 +477,7 @@ static int is_core_dump_opened(void)
+ }
+ #endif
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ int sock = 0;
+ #endif
+ 
+@@ -506,7 +506,7 @@ int main(int argc, char* argv[])
+     RDK_LOGGER_INIT();
+ #endif
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ 	int id=0;
+ 	id=getuid();
+ #endif
+@@ -531,7 +531,7 @@ int main(int argc, char* argv[])
+     pComponentName = gpPnmStartCfg->ComponentName;
+ 
+ //REFPLTV-5 : RDKB Container lxcclient code to send events from pandm to host
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ if(id != 0)
+ {
+     struct sockaddr_in serv_addr;
+diff --git a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+index 9f9b9483..3ddf933d 100644
+--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
++++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+@@ -96,7 +96,7 @@
+ #include "cm_hal_oem.h"
+ #endif
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ #include <unistd.h>
+ #include <sys/types.h>
+ #endif
+@@ -206,7 +206,7 @@ static const char *atomIp = ATOM_IP;
+     #define BLOCKLIST_FILE "/opt/secure/Blocklist_file.txt"
+ #endif
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ int sock;
+ int id = 0;
+ #endif
+@@ -1158,7 +1158,7 @@ DeviceInfo_SetParamBoolValue
+ {
+     PCOSA_DATAMODEL_DEVICEINFO      pMyObject = (PCOSA_DATAMODEL_DEVICEINFO)g_pCosaBEManager->hDeviceInfo;
+     BOOL                            bReturnValue;
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+     id =getuid();    
+ #endif
+     
+@@ -1180,7 +1180,7 @@ DeviceInfo_SetParamBoolValue
+         {
+ 		/* Restart Firewall */
+ 		v_secure_system("sysevent set firewall-restart");
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                if(id!=0)
+                {
+                        char *lxcevt = "sysevent set firewall-restart";
+@@ -7846,7 +7846,7 @@ Iot_SetParamBoolValue
+     /* check the parameter name and set the corresponding value */
+     if (strcmp(ParamName, "X_RDKCENTRAL-COM_ENABLEIOT") == 0)
+     {
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+        id=getuid();
+ #endif
+ 
+@@ -7859,7 +7859,7 @@ Iot_SetParamBoolValue
+                 if(bValue){
+                    AnscTraceWarning(("IOT_LOG : Raise IOT event up from DML\n"));
+                    v_secure_system("sysevent set iot_status up");
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                if(id!=0)
+                {
+                  char *lxcevt = "sysevent set iot_status up";
+@@ -7870,7 +7870,7 @@ Iot_SetParamBoolValue
+                 else{
+                    AnscTraceWarning(("IOT_LOG : Raise IOT event down from DML\n"));
+                    v_secure_system("sysevent set iot_status down");
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                 if(id!=0)
+                  {
+                    char *lxcevt = "sysevent set iot_status down";
+@@ -11863,7 +11863,7 @@ AllowOpenPorts_SetParamBoolValue
+ 
+             // restart firewall
+             v_secure_system("sysevent set firewall-restart");
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+       if(id!=0)
+        {
+ 		   char *lxcevt = "sysevent set firewall-restart";
+@@ -23940,7 +23940,7 @@ SelfHeal_SetParamUlongValue
+ 	    AnscTraceWarning(("Minimum interval is 2 for %s !\n", ParamName));
+ 	    return FALSE;
+ 	}
+-#if defined(_ARRIS_XB6_PRODUCT_REQ_) || defined(_CBR_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || \
++#if defined(_ARRIS_XB6_PRODUCT_REQ_) || defined(_CBR_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || \
+ (defined(_XB6_PRODUCT_REQ_) && defined(_COSA_BCM_ARM_))
+ 	syscfg_get( NULL, "resource_monitor_interval", buf, sizeof(buf));
+         if( 0 == strlen(buf) )
+diff --git a/source/TR-181/middle_layer_src/cosa_users_internal.c b/source/TR-181/middle_layer_src/cosa_users_internal.c
+index 99a47045..4a62d9bf 100644
+--- a/source/TR-181/middle_layer_src/cosa_users_internal.c
++++ b/source/TR-181/middle_layer_src/cosa_users_internal.c
+@@ -171,7 +171,7 @@ CosaUsersInitialize
+     errno_t safec_rc = -1;
+     int res;
+     
+-    #if defined(_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)
++    #if defined(_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+         //No need to remove any hardcoded passwords
+     #else
+         /* Remove hardcoded passwords*/
+diff --git a/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c b/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
+index 402ac67a..e22eb941 100644
+--- a/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
++++ b/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
+@@ -2114,7 +2114,7 @@ LanMngm_SetParamUlongValue
+             return FALSE;
+         #endif
+ 
+-	#if !defined(_PLATFORM_RASPBERRYPI_)
++	#if !defined(_PLATFORM_RASPBERRYPI_) || !defined(_PLATFORM_BANANAPI_R4_)
+ 	//RDKB-27656 : Bridge Mode must not set to true using WEBPA & dmcli in ETHWAN mode
+ 	#if 0
+         char buf[16] = {0};
+-- 
+2.47.0
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-DhcpManager-changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-DhcpManager-changes.patch
@@ -1,0 +1,91 @@
+From f370093e488a8a687ebde7c356953e280049dae5 Mon Sep 17 00:00:00 2001
+From: cpokur625 <chandrakanth_pokuru2@comcast.com>
+Date: Mon, 14 Oct 2024 22:33:59 +0000
+Subject: [PATCH 1/2] RDKBACCL-275 : Review generic rdk-b code and introduce
+ platform specific flags
+
+Reason for change: Build fails if MOCA not enabled
+Test Procedure: Build and test wan connectivity
+Risks: Low
+
+Change-Id: Ib0044f72b6661b1640a3cbee7d05195349c2c7e2
+Signed-off-by: cpokur625 <chandrakanth_pokuru2@comcast.com>
+---
+ source/TR-181/board_sbapi/cosa_dhcpv4_apis.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/source/TR-181/board_sbapi/cosa_dhcpv4_apis.c b/source/TR-181/board_sbapi/cosa_dhcpv4_apis.c
+index a9d52d9..f0d8805 100644
+--- a/source/TR-181/board_sbapi/cosa_dhcpv4_apis.c
++++ b/source/TR-181/board_sbapi/cosa_dhcpv4_apis.c
+@@ -592,8 +592,9 @@ int usg_get_cpe_associate_interface(char *pMac, char ifname[64])
+             rc = strcpy_s(ifname, 64, "Device.MoCA.Interface.1");
+             ERR_CHK(rc);
+         }
+-        else {
++        else
+ #endif
++	{
+             rc = strcpy_s(ifname, 64, "Device.Ethernet.Interface.x");
+             ERR_CHK(rc);
+         }
+-- 
+2.47.0
+
+
+From dac8aa66364cc2f0724ffcc923f95452947bd090 Mon Sep 17 00:00:00 2001
+From: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+Date: Thu, 10 Oct 2024 07:32:57 +0000
+Subject: [PATCH 2/2] RDKBACCL-275 :  Review generic rdk-b code and introduce
+ platform specific flags
+
+Reason for change : Changes for DhcpManager for BananaPi R4
+Test Procedure: Build and flash the image.erouter0 should get ip
+Risks: None
+
+Change-Id: I2275b65e84004989d271db84a22e46ef3109865b
+Signed-off-by: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+---
+ source/TR-181/board_sbapi/cosa_dhcpv6_apis.c                  | 3 +++
+ .../TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c  | 4 ++--
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/source/TR-181/board_sbapi/cosa_dhcpv6_apis.c b/source/TR-181/board_sbapi/cosa_dhcpv6_apis.c
+index 74eaf76..4b4c1da 100644
+--- a/source/TR-181/board_sbapi/cosa_dhcpv6_apis.c
++++ b/source/TR-181/board_sbapi/cosa_dhcpv6_apis.c
+@@ -2906,6 +2906,9 @@ CosaDmlDhcpv6cGetEnabled
+     BOOL dibblerEnabled = FALSE;
+ #elif defined(_PLATFORM_RASPBERRYPI_) && defined (FEATURE_RDKB_WAN_MANAGER)
+     BOOL dibblerEnabled = FALSE;
++#elif defined(_PLATFORM_BANANAPI_R4_) && defined (FEATURE_RDKB_WAN_MANAGER)
++    BOOL dibblerEnabled = FALSE;
++    
+ #endif
+ 
+ // For XB3, AXB6 if dibbler flag enabled, check dibbler-client process status
+diff --git a/source/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c b/source/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
+index 84934bf..e71b391 100755
+--- a/source/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
++++ b/source/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
+@@ -213,7 +213,7 @@ void* WebGuiRestart( void *arg )
+ }
+ 
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)  || defined(_PLATFORM_BANANAPI_R4_)
+ static int
+ DmSetBool(const char *param, BOOL value)
+ {
+@@ -1084,7 +1084,7 @@ CosaDmlLanMngm_SetConf(ULONG ins, PCOSA_DML_LAN_MANAGEMENT pLanMngm)
+     }
+ #endif
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+     char buf[7] = {0};
+     BOOL value;
+     snprintf(buf,sizeof(buf),"%d",bridge_info.mode);
+-- 
+2.47.0
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-GwProvApp-changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-GwProvApp-changes.patch
@@ -1,0 +1,457 @@
+From 9144851550c8a8c497fd8c81f4b86c56bac2e53e Mon Sep 17 00:00:00 2001
+From: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+Date: Wed, 9 Oct 2024 10:06:16 +0000
+Subject: [PATCH] RDKBACCL-275 :  Review generic rdk-b code and introduce
+ platform specific flags
+
+Reason for change : Changes for GwpRovApp for BananaPi R4
+Test Procedure: Build and flash the image.erouter0 should get ip
+Risks: None
+
+Change-Id: I09a1f32cbfbc3381d9a2546bc4e4cc57321bf011
+---
+ source/autowan.c                 |  2 +-
+ source/gw_prov_sm.c              | 80 ++++++++++++++++----------------
+ source/gw_prov_sm_generic.c      | 12 ++---
+ source/gw_prov_sm_generic_main.c |  2 +-
+ 4 files changed, 48 insertions(+), 48 deletions(-)
+
+diff --git a/source/autowan.c b/source/autowan.c
+index 97afb8c..8b90e45 100644
+--- a/source/autowan.c
++++ b/source/autowan.c
+@@ -942,7 +942,7 @@ CosaDmlEthWanSetEnable
+         BOOL                       bEnable
+     )
+ {
+-#if ((defined (_COSA_BCM_ARM_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_)) || defined(INTEL_PUMA7) || defined(_CBR2_PRODUCT_REQ_) || defined(_COSA_QCA_ARM_))
++#if ((defined (_COSA_BCM_ARM_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_)) || defined(INTEL_PUMA7) || defined(_CBR2_PRODUCT_REQ_) || defined(_COSA_QCA_ARM_) ) 
+ 
+ #if !defined(AUTO_WAN_ALWAYS_RECONFIG_EROUTER)
+     {
+diff --git a/source/gw_prov_sm.c b/source/gw_prov_sm.c
+index b7d56cb..a3648c7 100644
+--- a/source/gw_prov_sm.c
++++ b/source/gw_prov_sm.c
+@@ -56,7 +56,7 @@
+ #include <sys/socket.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ #include <sys/types.h>
+ #endif
+ #include <unistd.h>
+@@ -77,7 +77,7 @@
+ #include "autowan.h"
+ #include "gw_prov_sm.h"
+ #endif
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ #if !defined (_COSA_BCM_ARM_)
+ #include "docsis_esafe_db.h"
+ #endif
+@@ -104,7 +104,7 @@
+ #include "platform_hal.h"
+ #endif
+ //Added for lxcserver thread function
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ #define PORT 8081
+ #endif
+ 
+@@ -362,7 +362,7 @@ int sysevent_fd_gs;
+ token_t sysevent_token_gs;
+ #endif
+ static pthread_t sysevent_tid;
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ static pthread_t linkstate_tid;
+ static pthread_t lxcserver_tid;
+ #endif
+@@ -460,7 +460,7 @@ static int getSyseventBridgeMode(int erouterMode, int bridgeMode) {
+ }
+ 
+ 
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ /**************************************************************************/
+ /*! \fn STATUS GW_TlvParserInit(void)
+  **************************************************************************
+@@ -1020,7 +1020,7 @@ static int GWP_SysCfgSetInt(const char *name, int int_value)
+    return syscfg_set_u(NULL, name, int_value);
+ }
+ 
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ /**************************************************************************/
+ /*! \fn static STATUS GWP_UpdateEsafeAdminMode()
+  **************************************************************************
+@@ -1076,7 +1076,7 @@ static void validate_mode(int *bridge_mode, int *eRouterMode)
+ 	GWPROV_PRINT(" %s : bridge_mode = %d , eRouterMode = %d \n", __FUNCTION__, *bridge_mode, *eRouterMode);
+  }
+ 
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ void docsis_gotEnable_callback(unsigned char state)
+ {
+ 	GWPROV_PRINT(" Entry %s , state = %d \n", __FUNCTION__, state);
+@@ -1155,7 +1155,7 @@ static void GWP_DocsisInited(void)
+ **************************************************************************/
+ static void GWP_EnableERouter(void)
+ {
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ 	GWPROV_PRINT(" Entry %s \n", __FUNCTION__);
+     /* Update ESAFE state */
+     GWP_UpdateEsafeAdminMode(eRouterMode);
+@@ -1223,7 +1223,7 @@ static void GWP_EnterRouterMode(void)
+ **************************************************************************/
+ static void GWP_DisableERouter(void)
+ {
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ 	GWPROV_PRINT(" Entry %s \n", __FUNCTION__);
+     /* Update ESAFE state */
+     GWP_UpdateEsafeAdminMode(eRouterMode);
+@@ -1382,7 +1382,7 @@ static void GWP_UpdateERouterMode(void)
+             }
+             else  // remain enabled, switch mode
+             {
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+                 /* Update ESAFE state */
+                 GWP_UpdateEsafeAdminMode(eRouterMode);
+ #endif
+@@ -1457,7 +1457,7 @@ static void GWP_ProcessUtopiaRestart(void)
+ //     }
+ }
+ 
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ /**************************************************************************/
+ /*! \fn int GWP_ProcessIpv4Down();
+  **************************************************************************
+@@ -1690,7 +1690,7 @@ static void check_lan_wan_ready()
+ 		}
+ 	}
+ }
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ /**************************************************************************/
+ /*! \fn void *GWP_lxcserver_threadfunc(void *data)
+  **************************************************************************
+@@ -1920,7 +1920,7 @@ static void *GWP_sysevent_threadfunc(void *data)
+                 ERR_CHK(rc);
+                 if ((ind == 0) && (rc == EOK))
+                 {
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+                     GWP_ProcessIpv4Up();
+ #endif
+                 }
+@@ -1930,7 +1930,7 @@ static void *GWP_sysevent_threadfunc(void *data)
+                     ERR_CHK(rc);
+                     if ((ind == 0) && (rc == EOK))
+                     {
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+                          GWP_ProcessIpv4Down();
+ #endif
+                     }
+@@ -1942,7 +1942,7 @@ static void *GWP_sysevent_threadfunc(void *data)
+                 ERR_CHK(rc);
+                 if ((ind == 0) && (rc == EOK))
+                 {
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+                     GWP_ProcessIpv6Up();
+ #endif
+                 }
+@@ -1952,7 +1952,7 @@ static void *GWP_sysevent_threadfunc(void *data)
+                     ERR_CHK(rc);
+                     if ((ind == 0) && (rc == EOK))
+                     {
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+                         GWP_ProcessIpv6Down();
+ #endif
+                      }
+@@ -2151,7 +2151,7 @@ static void *GWP_sysevent_threadfunc(void *data)
+                 ERR_CHK(rc);
+                 if ((ind == 0) && (rc == EOK)){
+                     if (!webui_started) { 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ 
+                        rc = strcmp_s("bridge-status", strlen("bridge-status"),name, &ind);
+                        ERR_CHK(rc);
+@@ -2239,7 +2239,7 @@ static void *GWP_sysevent_threadfunc(void *data)
+                 /* Coverity Issue Fix - CID:79291 : UnInitialised varible  */
+                 unsigned char soladdr[ NETUTILS_IPv6_GLOBAL_ADDR_LEN ] = {0} ;
+                 inet_pton(AF_INET6, val, v6addr);
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+                 getMultiCastGroupAddress(v6addr,soladdr);
+ #endif
+                 inet_ntop(AF_INET6, soladdr, val, sizeof(val));
+@@ -2451,7 +2451,7 @@ static int GWP_act_DocsisLinkUp_callback()
+ #endif
+ 
+     
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+      char *temp;
+      char wanPhyName[20];
+      char out_value[20];
+@@ -2537,7 +2537,7 @@ static int GWP_act_DocsisLinkUp_callback()
+ }
+ 
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ /**************************************************************************/
+ /*! \fn void *GWP_linkstate_threadfunc(void *)
+  **************************************************************************
+@@ -2676,7 +2676,7 @@ void GWP_Util_get_shell_output( char *cmd, char *out, int len )
+ }
+ 
+ /* GWP_UpdateTr069CfgThread() */
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ static void *GWP_UpdateTr069CfgThread( void *data )
+ {
+ 	int 	IsNeedtoProceedFurther    = TRUE;
+@@ -2799,7 +2799,7 @@ static void *GWP_UpdateTr069CfgThread( void *data )
+ 	return data;
+ }
+ #endif
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ /**************************************************************************/
+ /*! \fn int GWP_act_DocsisCfgfile(SME_APP_T *app, SME_EVENT_T *event);
+  **************************************************************************
+@@ -3060,7 +3060,7 @@ static int GWP_act_DocsisInited_callback (void)
+ {
+     esafeErouterOperModeExtIf_e operMode;
+     //DOCSIS_Esafe_Db_Enable_e eRouterModeTmp; 
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+     DOCSIS_Esafe_Db_extIf_e eRouterModeTmp;
+ #endif
+     unsigned char lladdr[ NETUTILS_IPv6_GLOBAL_ADDR_LEN ] = {0};
+@@ -3070,7 +3070,7 @@ static int GWP_act_DocsisInited_callback (void)
+     /* Coverity Issue Fix - CID:73933 : UnInitialised variable */
+     char soladdrStr[64] = {0};
+     GWPROV_PRINT(" Entry %s \n", __FUNCTION__);
+-#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(INTEL_PUMA7) && !defined(_COSA_BCM_ARM_) && !defined(_COSA_QCA_ARM_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(INTEL_PUMA7) && !defined(_COSA_BCM_ARM_) && !defined(_COSA_QCA_ARM_) && !defined(_PLATFORM_BANANAPI_R4_)
+     /* Docsis initialized */
+     printf("Got DOCSIS Initialized\n");
+ 
+@@ -3115,7 +3115,7 @@ static int GWP_act_DocsisInited_callback (void)
+ //     }
+ #if !defined(INTEL_PUMA7) && !defined(_COSA_BCM_MIPS_) && !defined(_COSA_BCM_ARM_) && !defined(_COSA_QCA_ARM_)
+ 	printf("Not Initializing bridge_mode and eRouterMode for XB3\n");
+-#elif defined(_PLATFORM_RASPBERRYPI_)
++#elif defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+     printf("Not Initializing bridge_mode and eRouterMode for Raspberry Pi\n");
+ #else
+     bridge_mode = GWP_SysCfgGetInt("bridge_mode");
+@@ -3128,7 +3128,7 @@ static int GWP_act_DocsisInited_callback (void)
+     sysevent_set(sysevent_fd_gs, sysevent_token_gs, "bridge_mode", BridgeMode, 0);
+ #endif
+   
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+     GWP_DocsisInited();
+ #endif
+ 
+@@ -3145,7 +3145,7 @@ static int GWP_act_DocsisInited_callback (void)
+ #endif
+ 
+       sysevent_set(sysevent_fd_gs, sysevent_token_gs, "docsis-initialized", "1", 0);
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ 
+     /* Must set the ESAFE Enable state before replying to the DocsisInit event */
+     eRouterModeTmp = eRouterMode;
+@@ -3216,7 +3216,7 @@ static int GWP_act_DocsisInited_callback (void)
+     }
+ 
+     //calculate cm base solicited node address
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+     getInterfaceLinkLocalAddress(IFNAME_WAN_0, lladdr);
+     
+    
+@@ -3246,7 +3246,7 @@ static int GWP_act_DocsisInited_callback (void)
+ static int GWP_act_ProvEntry_callback (void)
+ {
+     char BridgeMode[2] = {0};
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+     int uid = 0;
+     uid = getuid();
+ #endif
+@@ -3254,7 +3254,7 @@ static int GWP_act_ProvEntry_callback (void)
+ #ifdef MULTILAN_FEATURE
+     macaddr_t macAddr;
+ #endif
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+     GWPROV_PRINT("Entry %s \n", __FUNCTION__);
+     //v_secure_system("sysevent set lan-start");
+    
+@@ -3323,7 +3323,7 @@ static int GWP_act_ProvEntry_callback (void)
+     printf("************************value of command = ifconfig %s up ***********************\n", wanPhyName);
+     v_secure_system("ifconfig %s up", wanPhyName);
+ #endif
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ if( uid == 0 )
+ {
+ #endif
+@@ -3344,20 +3344,20 @@ if( uid == 0 )
+ 	AutoWAN_main();
+ #endif
+ #endif
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ }
+ #endif      
+     //Make another connection for gets/sets
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ if ( uid == 0 )
+ {
+ #endif
+     sysevent_fd_gs = sysevent_open("127.0.0.1", SE_SERVER_WELL_KNOWN_PORT, SE_VERSION, "gw_prov-gs", &sysevent_token_gs);
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ }
+ #endif
+ // rdkb rpi container :: lxcserver funbction is needed to run in host for listening event from ccsppandm
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+     if( uid == 0 )
+     {
+         //rdkb rpi container :: lxc-server thread create
+@@ -3391,14 +3391,14 @@ if ( uid == 0 )
+ 
+     /* Now that we have the ICC que (SME) and we are registered on the docsis INIT    */
+     /* event, we can notify PCD to continue                                           */
+-#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(INTEL_PUMA7)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(INTEL_PUMA7) && !defined(_PLATFORM_BANANAPI_R4_)
+     sendProcessReadySignal();
+ #endif
+ 
+     /* Initialize Switch */
+     // VEN_SWT_InitSwitch();
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+     printf("Thread to monitor link status \n");
+     pthread_create(&linkstate_tid, NULL, GWP_linkstate_threadfunc, NULL);
+ #endif
+@@ -3440,7 +3440,7 @@ if ( uid == 0 )
+     return 0;
+ }
+ 
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ static int GWP_act_DocsisTftpOk_callback(){
+ 	GWPROV_PRINT(" Entry %s \n", __FUNCTION__);
+     gDocTftpOk = 1;
+@@ -3604,7 +3604,7 @@ void low_latency_docsis_status_check(void)
+  **************************************************************************/
+ int main(int argc, char *argv[])
+ {
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+      int uid = 0;
+      uid = getuid();
+ #endif
+@@ -3620,7 +3620,7 @@ int main(int argc, char *argv[])
+ 
+     t2_init("ccsp-gwprovapp");
+ 
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ 
+     #ifdef FEATURE_SUPPORT_RDKLOG
+        rdk_logger_init(DEBUG_INI_NAME);
+diff --git a/source/gw_prov_sm_generic.c b/source/gw_prov_sm_generic.c
+index 8aacb9d..85fb935 100644
+--- a/source/gw_prov_sm_generic.c
++++ b/source/gw_prov_sm_generic.c
+@@ -56,7 +56,7 @@
+ #include <sys/socket.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ #include <sys/types.h>
+ #endif
+ #include <unistd.h>
+@@ -94,7 +94,7 @@
+ #include "platform_hal.h"
+ #endif
+ //Added for lxcserver thread function
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ #define PORT 8081
+ #endif
+ 
+@@ -213,7 +213,7 @@ void GWPROV_PRINT(const char *format, ...)
+ #define ETHWAN_FILE     "/nvram/ETHWAN_ENABLE"
+ #endif
+ 
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ static void _get_shell_output (FILE *fp, char *buf, int len);
+ #endif
+ 
+@@ -1202,7 +1202,7 @@ static void *GWP_sysevent_threadfunc(void *data)
+                   ERR_CHK(rc);
+                   if ((ind == 0) && (rc == EOK)){
+                       if (!webui_started) { 
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                           GWPROV_PRINT(" bridge-status = %s start webgui.sh \n", val );
+                           v_secure_system("/bin/sh /etc/webgui.sh &");
+ #elif  defined(_CBR2_PRODUCT_REQ_)
+@@ -1311,7 +1311,7 @@ static void *GWP_sysevent_threadfunc(void *data)
+                   /* Coverity Issue Fix - CID:79291 : UnInitialised varible  */
+                   unsigned char soladdr[ NETUTILS_IPv6_GLOBAL_ADDR_LEN / sizeof(unsigned char) ] = {0} ;
+                   inet_pton(AF_INET6, val, v6addr);
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+                   getMultiCastGroupAddress(v6addr,soladdr);
+ #endif
+                   inet_ntop(AF_INET6, soladdr, val, sizeof(val));
+@@ -1586,7 +1586,7 @@ STATIC void LAN_start(void)
+    return;
+ }
+ 
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+ static void _get_shell_output (FILE *fp, char *buf, int len)
+ {
+     if (fp == NULL)
+diff --git a/source/gw_prov_sm_generic_main.c b/source/gw_prov_sm_generic_main.c
+index 89696b5..7d9052b 100644
+--- a/source/gw_prov_sm_generic_main.c
++++ b/source/gw_prov_sm_generic_main.c
+@@ -35,7 +35,7 @@
+ #include <sys/socket.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+-#if !defined(_PLATFORM_RASPBERRYPI_)
++#if !defined(_PLATFORM_RASPBERRYPI_) || !defined(_PLATFORM_BANANAPI_R4_)
+ #include <sys/types.h>
+ #endif
+ #include <unistd.h>
+-- 
+2.47.0
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-rdk-wanmanger-changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-rdk-wanmanger-changes.patch
@@ -1,0 +1,333 @@
+Index: git/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
+===================================================================
+--- git.orig/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
++++ git/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
+@@ -40,7 +40,7 @@
+ #include "wanmgr_dhcpv4_apis.h"
+ #include "wanmgr_dhcpv6_apis.h"
+ #include "wanmgr_data.h"
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ #include "wanmgr_utils.h"
+ #endif
+ 
+@@ -417,7 +417,7 @@ BOOL WanIf_SetParamStringValue(ANSC_HAND
+             if (strcmp(ParamName, "CustomConfigPath") == 0)
+             {
+                 AnscCopyString(pWanDmlIface->CustomConfigPath, pString);
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                 WanMgr_SetRestartWanInfo(WAN_CUSTOM_CONFIG_PATH_PARAM_NAME, pWanDmlIface->uiIfaceIdx, pString);
+ #endif
+                 ret = TRUE;
+@@ -573,7 +573,7 @@ BOOL WanIf_SetParamBoolValue(ANSC_HANDLE
+             if (strcmp(ParamName, "ConfigureWanEnable") == 0)
+             {
+                 pWanDmlIface->WanConfigEnabled  = bValue;
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                 WanMgr_SetRestartWanInfo(WAN_CONFIGURE_WAN_ENABLE_PARAM_NAME, pWanDmlIface->uiIfaceIdx, pWanDmlIface->WanConfigEnabled?"true":"false");
+ #endif
+                 ret = TRUE;
+@@ -582,7 +582,7 @@ BOOL WanIf_SetParamBoolValue(ANSC_HANDLE
+             if (strcmp(ParamName, "EnableCustomConfig") == 0)
+             {
+                 pWanDmlIface->CustomConfigEnable  = bValue;
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                 WanMgr_SetRestartWanInfo(WAN_ENABLE_CUSTOM_CONFIG_PARAM_NAME, pWanDmlIface->uiIfaceIdx, pWanDmlIface->CustomConfigEnable?"true":"false");
+ #endif
+                 ret = TRUE;
+@@ -590,7 +590,7 @@ BOOL WanIf_SetParamBoolValue(ANSC_HANDLE
+             if (strcmp(ParamName, "EnableOperStatusMonitor") == 0)
+             {
+                 pWanDmlIface->MonitorOperStatus = bValue;
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                 WanMgr_SetRestartWanInfo(WAN_ENABLE_OPER_STATUS_MONITOR_PARAM_NAME, pWanDmlIface->uiIfaceIdx, pWanDmlIface->MonitorOperStatus?"true":"false");
+ #endif
+                 ret = TRUE;
+@@ -1737,7 +1737,7 @@ BOOL WanVirtualIf_SetParamStringValue(AN
+         if (strcmp(ParamName, "Name") == 0)
+         {
+             AnscCopyString(p_VirtIf->Name, pString);
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+             WanMgr_SetRestartWanInfo(WAN_NAME_PARAM_NAME, p_VirtIf->VirIfIdx, pString);
+ #endif
+             ret = TRUE;
+Index: git/source/TR-181/middle_layer_src/wanmgr_dml_iface_apis.c
+===================================================================
+--- git.orig/source/TR-181/middle_layer_src/wanmgr_dml_iface_apis.c
++++ git/source/TR-181/middle_layer_src/wanmgr_dml_iface_apis.c
+@@ -40,7 +40,7 @@
+ #include "wanmgr_dhcpv4_apis.h"
+ #include "wanmgr_dhcpv6_apis.h"
+ #include "wanmgr_data.h"
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+ #include "wanmgr_utils.h"
+ #endif
+ 
+@@ -337,7 +337,7 @@ BOOL WanIf_SetParamStringValue(ANSC_HAND
+             if (strcmp(ParamName, "CustomConfigPath") == 0)
+             {
+                 AnscCopyString(pWanDmlIface->CustomConfigPath, pString);
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                 WanMgr_SetRestartWanInfo(WAN_CUSTOM_CONFIG_PATH_PARAM_NAME, pWanDmlIface->uiIfaceIdx, pString);
+ #endif
+                 ret = TRUE;
+@@ -451,7 +451,7 @@ BOOL WanIf_SetParamBoolValue(ANSC_HANDLE
+             if (strcmp(ParamName, "ConfigureWanEnable") == 0)
+             {
+                 pWanDmlIface->WanConfigEnabled  = bValue;
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                 WanMgr_SetRestartWanInfo(WAN_CONFIGURE_WAN_ENABLE_PARAM_NAME, pWanDmlIface->uiIfaceIdx, pWanDmlIface->WanConfigEnabled?"true":"false");
+ #endif
+                 ret = TRUE;
+@@ -460,7 +460,7 @@ BOOL WanIf_SetParamBoolValue(ANSC_HANDLE
+             if (strcmp(ParamName, "EnableCustomConfig") == 0)
+             {
+                 pWanDmlIface->CustomConfigEnable  = bValue;
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                 WanMgr_SetRestartWanInfo(WAN_ENABLE_CUSTOM_CONFIG_PARAM_NAME, pWanDmlIface->uiIfaceIdx, pWanDmlIface->CustomConfigEnable?"true":"false");
+ #endif
+                 ret = TRUE;
+@@ -468,7 +468,7 @@ BOOL WanIf_SetParamBoolValue(ANSC_HANDLE
+             if (strcmp(ParamName, "EnableOperStatusMonitor") == 0)
+             {
+                 pWanDmlIface->MonitorOperStatus = bValue;
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                 WanMgr_SetRestartWanInfo(WAN_ENABLE_OPER_STATUS_MONITOR_PARAM_NAME, pWanDmlIface->uiIfaceIdx, pWanDmlIface->MonitorOperStatus?"true":"false");
+ #endif
+                 ret = TRUE;
+@@ -1187,7 +1187,7 @@ BOOL WanIfCfg_SetParamStringValue(ANSC_H
+             if (strcmp(ParamName, "Name") == 0)
+             {
+                 AnscCopyString(pWanDmlIface->VirtIfList->Name, pString);
+-#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)
++#if defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
+                 WanMgr_SetRestartWanInfo(WAN_NAME_PARAM_NAME, pWanDmlIface->uiIfaceIdx, pString);
+ #endif
+                 ret = TRUE;
+Index: git/source/WanManager/wanmgr_interface_sm.c
+===================================================================
+--- git.orig/source/WanManager/wanmgr_interface_sm.c
++++ git/source/WanManager/wanmgr_interface_sm.c
+@@ -1023,7 +1023,7 @@ static int checkIpv6AddressAssignedToBri
+     char lanPrefix[BUFLEN_128] = {0};
+     int ret = RETURN_ERR;
+
+-#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)) &&  !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)//TODO: V6 handled in PAM
++#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)) &&  !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)//TODO: V6 handled in PAM
+     CcspTraceWarning(("%s %d Ipv6 handled in PAM. No need to check here.  \n",__FUNCTION__, __LINE__));
+     return RETURN_OK;
+ #endif
+@@ -1262,7 +1262,7 @@ static int wan_tearDownIPv4(WanMgr_Iface
+     DML_WAN_IFACE * pInterface = pWanIfaceCtrl->pIfaceData;
+     DML_VIRTUAL_IFACE* p_VirtIf = WanMgr_getVirtualIfaceById(pInterface->VirtIfList, pWanIfaceCtrl->VirIfIdx);
+
+-#if !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)) //TODO:  XB devices use the DNS of primary for backup.
++#if !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)) //TODO:  XB devices use the DNS of primary for backup.
+         /** Reset IPv4 DNS configuration. */
+     if (RETURN_OK != wan_updateDNS(pWanIfaceCtrl, FALSE, (p_VirtIf->IP.Ipv6Status == WAN_IFACE_IPV6_STATE_UP)))
+     {
+@@ -1386,7 +1386,7 @@ static int wan_setUpIPv6(WanMgr_IfaceSM_
+         }
+         wanmgr_services_restart();
+
+-#if !defined (_XB6_PRODUCT_REQ_) && !defined (_CBR2_PRODUCT_REQ_) && !defined(_PLATFORM_RASPBERRYPI_) //parodus uses cmac for xb platforms
++#if !defined (_XB6_PRODUCT_REQ_) && !defined (_CBR2_PRODUCT_REQ_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_) //parodus uses cmac for xb platforms
+         // set wan mac because parodus depends on it to start.
+         if(ANSC_STATUS_SUCCESS == WanManager_get_interface_mac(p_VirtIf->IP.Ipv6Data.ifname, ifaceMacAddress, sizeof(ifaceMacAddress)))
+         {
+@@ -1415,7 +1415,7 @@ static int wan_tearDownIPv6(WanMgr_Iface
+     DML_WAN_IFACE * pInterface = pWanIfaceCtrl->pIfaceData;
+     DML_VIRTUAL_IFACE* p_VirtIf = WanMgr_getVirtualIfaceById(pInterface->VirtIfList, pWanIfaceCtrl->VirIfIdx);
+
+-#if !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)) //TODO: XB devices use the DNS of primary for backup.
++#if !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)) //TODO: XB devices use the DNS of primary for backup.
+     /** Reset IPv6 DNS configuration. */
+     if (RETURN_OK == wan_updateDNS(pWanIfaceCtrl, (p_VirtIf->IP.Ipv4Status == WAN_IFACE_IPV4_STATE_UP), FALSE))
+     {
+Index: git/source/WanManager/wanmgr_net_utils.c
+===================================================================
+--- git.orig/source/WanManager/wanmgr_net_utils.c
++++ git/source/WanManager/wanmgr_net_utils.c
+@@ -558,7 +558,7 @@ uint32_t WanManager_StartDhcpv6Client(DM
+ 
+     CcspTraceInfo(("Enter WanManager_StartDhcpv6Client for  %s \n", pVirtIf->Name));
+ 
+-#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)) //TODO: ipv6 handled in PAM
++#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)) //TODO: ipv6 handled in PAM
+     //Enable accept_ra while starting dhcpv6 for comcast devices.
+     WanMgr_Configure_accept_ra(pVirtIf, TRUE);
+     usleep(500000); //sleep for 500 milli seconds
+Index: git/source/WanManager/wanmgr_dhcpv6_apis.c
+===================================================================
+--- git.orig/source/WanManager/wanmgr_dhcpv6_apis.c
++++ git/source/WanManager/wanmgr_dhcpv6_apis.c
+@@ -1642,7 +1642,7 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_d
+         {
+             CcspTraceInfo(("assigned IPv6 address \n"));
+             connected = TRUE;
+-#if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) || (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)) //TODO: V6 handled in PAM
++#if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) || (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)) //TODO: V6 handled in PAM
+             /* TODO: Assign IPv6 address on Wan Interface when received, if dhcpv6 client didn't assign on the ineterface. 
+              * Currently dibbler client will assign IA_NA to the interface. 
+              * VISM will assign the prefix on LAN interface.  
+@@ -1672,7 +1672,7 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_d
+             connected = TRUE;
+ 
+             /* Update the WAN prefix validity time in the persistent storage */
+-#if !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) && !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))  //TODO: V6 handled in PAM
++#if !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) && !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_))  //TODO: V6 handled in PAM
+             if (pDhcp6cInfoCur->prefixVltime != pNewIpcMsg->prefixVltime)
+             {
+                 snprintf(set_value, sizeof(set_value), "%d", pNewIpcMsg->prefixVltime);
+@@ -1727,7 +1727,7 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_d
+             if (strcmp(pDhcp6cInfoCur->sitePrefix, pNewIpcMsg->sitePrefix) == 0)
+             {
+                 CcspTraceInfo(("remove prefix \n"));
+-#if !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) && !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))  //TODO: V6 handled in PAM
++#if !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) && !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_))  //TODO: V6 handled in PAM
+                 syscfg_set(NULL, SYSCFG_FIELD_IPV6_PREFIX, "");
+                 syscfg_set(NULL, SYSCFG_FIELD_PREVIOUS_IPV6_PREFIX, "");
+                 syscfg_set_commit(NULL, SYSCFG_FIELD_IPV6_PREFIX_ADDRESS, "");
+@@ -1737,7 +1737,7 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_d
+         }
+     }
+ 
+-#if !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)&& !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))  //TODO: V6 handled in PAM
++#if !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)&& !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_))  //TODO: V6 handled in PAM
+     /* dhcp6c receives domain name information */
+     if (pNewIpcMsg->domainNameAssigned && !IS_EMPTY_STRING(pNewIpcMsg->domainName))
+     {
+@@ -1771,7 +1771,7 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_d
+ 
+             if (strcmp(pDhcp6cInfoCur->address, guAddrPrefix))
+             {
+-#if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) || (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))  //TODO: V6 handled in PAM
++#if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) || (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_))  //TODO: V6 handled in PAM
+                 strncpy(pVirtIf->IP.Ipv6Data.address,guAddrPrefix, sizeof(pVirtIf->IP.Ipv6Data.address));
+                 pNewIpcMsg->addrAssigned = true;
+ #else
+@@ -1795,7 +1795,7 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_d
+         WANMGR_IPV6_DATA Ipv6DataTemp;
+         wanmgr_dchpv6_get_ipc_msg_info(&(Ipv6DataTemp), pNewIpcMsg);
+ 
+-#if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) || (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))//Do not compare if pdIfAddress and sitePrefix is empty. pdIfAddress Will be calculated while configuring LAN prefix.  //TODO: V6 handled in PAM
++#if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) || (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_))//Do not compare if pdIfAddress and sitePrefix is empty. pdIfAddress Will be calculated while configuring LAN prefix.  //TODO: V6 handled in PAM
+         if ((strlen(Ipv6DataTemp.address) > 0 && strcmp(Ipv6DataTemp.address, pDhcp6cInfoCur->address)) ||
+             ((Ipv6DataTemp.pdIfAddress) && (strlen(Ipv6DataTemp.pdIfAddress) > 0)&&
+             (strcmp(Ipv6DataTemp.pdIfAddress, pDhcp6cInfoCur->pdIfAddress))) ||
+@@ -1826,7 +1826,7 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_d
+             /*TODO: Revisit this*/
+             //call function for changing the prlft and vallft
+             // FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE : Handle Ip renew in handler thread. 
+-#if !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))  //TODO: V6 handled in PAM
++#if !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_))  //TODO: V6 handled in PAM
+             if ((WanManager_Ipv6AddrUtil(pVirtIf->Name, SET_LFT, pNewIpcMsg->prefixPltime, pNewIpcMsg->prefixVltime) < 0))
+             {
+                 CcspTraceError(("Life Time Setting Failed"));
+@@ -1906,7 +1906,7 @@ int setUpLanPrefixIPv6(DML_VIRTUAL_IFACE
+     CcspTraceInfo(("%s %d Updating SYSEVENT_CURRENT_WAN_IFNAME %s\n", __FUNCTION__, __LINE__,pVirtIf->IP.Ipv6Data.ifname));
+     sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_CURRENT_WAN_IFNAME, pVirtIf->IP.Ipv6Data.ifname, 0);
+ 
+-#if !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))  //TODO: V6 handled in PAM
++#if !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_))  //TODO: V6 handled in PAM
+     /* Enable accept ra */
+     WanMgr_Configure_accept_ra(pVirtIf, TRUE);
+ 
+Index: git/source/WanManager/wanmgr_data.c
+===================================================================
+--- git.orig/source/WanManager/wanmgr_data.c
++++ git/source/WanManager/wanmgr_data.c
+@@ -21,7 +21,7 @@
+ #include "wanmgr_data.h"
+ #include "wanmgr_rdkbus_apis.h"
+ 
+-#if defined(WAN_MANAGER_UNIFICATION_ENABLED) && (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))
++#if defined(WAN_MANAGER_UNIFICATION_ENABLED) && (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)) 
+ extern ANSC_STATUS WanMgr_CheckAndResetV2PSMEntries(UINT IfaceCount);
+ #endif
+ 
+@@ -246,7 +246,7 @@ ANSC_STATUS WanMgr_WanIfaceConfInit(WanM
+         }
+ 
+         pWanIfaceCtrl->ulTotalNumbWanInterfaces = uiTotalIfaces;
+-#if defined(WAN_MANAGER_UNIFICATION_ENABLED) && (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))
++#if defined(WAN_MANAGER_UNIFICATION_ENABLED) && (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_))
+         WanMgr_CheckAndResetV2PSMEntries(uiTotalIfaces);
+ #endif
+ 
+Index: git/source/WanManager/wanmgr_dhcp_legacy_apis.c
+===================================================================
+--- git.orig/source/WanManager/wanmgr_dhcp_legacy_apis.c
++++ git/source/WanManager/wanmgr_dhcp_legacy_apis.c
+@@ -1561,7 +1561,7 @@ void wanmgr_setSharedCGNAddress(char *Ip
+ }
+ #endif//_DT_WAN_Manager_Enable_
+ 
+-#if defined(WAN_MANAGER_UNIFICATION_ENABLED) && (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))
++#if defined(WAN_MANAGER_UNIFICATION_ENABLED) && (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)) 
+ #define DEFAULT_PSM_FILE          "/usr/ccsp/config/bbhm_def_cfg.xml"
+ /* TODO : This is a function to recover v2 PSM entries if it is written with wrong values in older builds. 
+  * This should be removed after successful migration to unification builds 
+Index: git/source/WanManager/wanmgr_sysevents.c
+===================================================================
+--- git.orig/source/WanManager/wanmgr_sysevents.c
++++ git/source/WanManager/wanmgr_sysevents.c
+@@ -216,7 +216,7 @@ ANSC_STATUS wanmgr_set_Ipv4Sysevent(cons
+     }
+     sysevent_set(sysevent_fd, sysevent_token,name, dhcp4Info->ip, 0);
+
+-#if !defined (_XB6_PRODUCT_REQ_) && !defined (_CBR2_PRODUCT_REQ_) && !defined(_PLATFORM_RASPBERRYPI_) //parodus uses cmac for xb platforms
++#if !defined (_XB6_PRODUCT_REQ_) && !defined (_CBR2_PRODUCT_REQ_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_) //parodus uses cmac for xb platforms
+     // set wan mac because parodus depends on it to start.
+     if(ANSC_STATUS_SUCCESS == WanManager_get_interface_mac(dhcp4Info->ifname, ifaceMacAddress, sizeof(ifaceMacAddress)))
+     {
+@@ -1208,7 +1208,7 @@ int Force_IPv6_toggle (char* wanInterfac
+ void wanmgr_Ipv6Toggle (void)
+ {
+     char v6Toggle[BUFLEN_128] = {0};
+-#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)) &&  !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)//TODO: V6 handled in PAM
++#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)) &&  !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)//TODO: V6 handled in PAM
+     /*Ipv6 handled in PAM.  No Toggle Needed. */
+     return;
+ #endif 
+Index: git/source/WanManager/wanmgr_policy_auto_impl.c
+===================================================================
+--- git.orig/source/WanManager/wanmgr_policy_auto_impl.c
++++ git/source/WanManager/wanmgr_policy_auto_impl.c
+@@ -120,7 +120,7 @@ static int WanMgr_RdkBus_AddAllIntfsToLa
+     return ANSC_STATUS_SUCCESS;
+ 
+ }
+-#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))
++#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)) 
+ //TODO: this is a workaround to support upgarde from Comcast autowan policy to Unification build
+ #define MAX_WanModeToIfaceMap 2
+ static const int lastWanModeToIface_map[MAX_WanModeToIfaceMap] = {2, 1}; 
+@@ -270,7 +270,7 @@ static void WanMgr_Policy_Auto_GetHighPr
+                     }
+                     // pWanIfaceData - is Wan-Enabled & has valid Priority
+                     if(pWanIfaceData->Selection.Priority < iSelPriority
+-#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))
++#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_))
+                         //TODO: this is a workaround to support upgarde from Comcast autowan policy to Unification build
+                         || isLastActiveLinkFromSysCfg(pWanIfaceData)
+ #endif    
+@@ -1261,7 +1261,7 @@ static WcAwPolicyState_t State_Interface
+         return STATE_AUTO_WAN_ERROR;
+     }
+ 
+-#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))
++#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)) 
+     // HW configuration already done using SelectedOperationalMode for XB platforms. Skipping this state.
+     CcspTraceInfo(("%s %d: HW configuration already done using SelectedOperationalMode.\n", __FUNCTION__, __LINE__));
+     return Transition_ActivatingInterface (pWanController);

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-startParodus-changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/BPI-startParodus-changes.patch
@@ -1,0 +1,32 @@
+From f2e5d7e98759e8160f4a66c251973bf87dac76b7 Mon Sep 17 00:00:00 2001
+From: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+Date: Wed, 14 Aug 2024 07:35:34 +0000
+Subject: [PATCH] RDKBACCL-275 :  Review generic rdk-b code and introduce
+ platform specific flags
+
+Reason for change : Changes for PandM
+Test Procedure: Build and flash the image.erouter0 should get ip
+Risks: None
+
+Change-Id: I706a244c9d4741dc1c1400a196622a7a5d33d61d
+Signed-off-by: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+---
+ source/parodusStart/start_parodus.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/parodusStart/start_parodus.c b/source/parodusStart/start_parodus.c
+index eae415a..ff8de83 100644
+--- a/source/parodusStart/start_parodus.c
++++ b/source/parodusStart/start_parodus.c
+@@ -46,7 +46,7 @@
+ #include "cJSON.h"
+ #include "safec_lib_common.h"
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+ #include "ccsp_vendor.h"
+ #endif
+ 
+-- 
+2.47.0
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
@@ -1,13 +1,13 @@
 include ccsp_common_bananapi.inc
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI_append += "file://test.patch;apply=no "
+SRC_URI_append += "file://BPI-rdk-wanmanger-changes.patch;apply=no "
 
 
 do_bananapi_patches() {
     cd ${S}
     if [ ! -e bananapi_patch_applied ]; then
-        bbnote "Patching BPI-ccsp-p-and-m-changes.patch"
-        patch -p1 < ${WORKDIR}/test.patch
+        bbnote "Patching BPI-rdk-wanmanger-changes.patch"
+        patch -p1 < ${WORKDIR}/BPI-rdk-wanmanger-changes.patch
     touch bananapi_patch_applied
     fi
 }

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
@@ -1,1 +1,15 @@
 include ccsp_common_bananapi.inc
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI_append += "file://test.patch;apply=no "
+
+
+do_bananapi_patches() {
+    cd ${S}
+    if [ ! -e bananapi_patch_applied ]; then
+        bbnote "Patching BPI-ccsp-p-and-m-changes.patch"
+        patch -p1 < ${WORKDIR}/test.patch
+    touch bananapi_patch_applied
+    fi
+}
+
+addtask bananapi_patches after do_unpack before do_compile

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/start-parodus.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/start-parodus.bbappend
@@ -1,1 +1,16 @@
 include ccsp_common_bananapi.inc
+
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
+
+SRC_URI_append += " \
+    file://BPI-startParodus-changes.patch;apply=no \
+"
+do_bananapi_patches() {
+    cd ${S}
+    if [ ! -e bananapi_patch_applied ]; then
+        bbnote "Patching BPI-startParodus-changes.patch file"
+        patch -p1 < ${WORKDIR}/BPI-startParodus-changes.patch
+        touch bananapi_patch_applied
+    fi
+}
+addtask bananapi_patches after do_unpack before do_configure

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-platform-generic_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-platform-generic_git.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI_append += "file://Add_ipv6_changes.patch"
+SRC_URI += " file://Add_ipv6_changes.patch"
+
 do_configure_append() {
      #For trimming the spaces
      sed -i "s/cat \/proc\/device-tree\/model/cat \/proc\/device-tree\/model | tr -d ' '/g" ${S}/rdkb_hal/src/platform/platform_hal.c

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/files/BPI-TestAndDiagnostic-changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/files/BPI-TestAndDiagnostic-changes.patch
@@ -1,0 +1,46 @@
+From ccbed91b47c3b5c2541f98029a03a7037503c3b2 Mon Sep 17 00:00:00 2001
+From: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+Date: Wed, 14 Aug 2024 07:28:24 +0000
+Subject: [PATCH] RDKBACCL-275 :  Review generic rdk-b code and introduce
+ platform specific flags
+
+Reason for change : Changes for PandM
+Test Procedure: Build and flash the image.erouter0 should get ip
+Risks: None
+
+Change-Id: I0817da18c5c355b342169e495038e57a58b32b41
+Signed-off-by: aishwarya_natarajan2 <aishwarya_natarajan2@comcast.com>
+---
+ source/dmltad/cosa_selfheal_dml.c | 2 +-
+ source/dmltad/diag.c              | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/source/dmltad/cosa_selfheal_dml.c b/source/dmltad/cosa_selfheal_dml.c
+index 15d4e79..b60337a 100644
+--- a/source/dmltad/cosa_selfheal_dml.c
++++ b/source/dmltad/cosa_selfheal_dml.c
+@@ -1592,7 +1592,7 @@ ResourceMonitor_SetParamUlongValue
+             return TRUE;
+         }
+   
+-#if defined(_ARRIS_XB6_PRODUCT_REQ_) || defined(_CBR_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || \
++#if defined(_ARRIS_XB6_PRODUCT_REQ_) || defined(_CBR_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || \
+ (defined(_XB6_PRODUCT_REQ_) && defined(_COSA_BCM_ARM_))
+         char buf[8];
+         errno_t rc = -1;
+diff --git a/source/dmltad/diag.c b/source/dmltad/diag.c
+index f719494..fb0ba38 100644
+--- a/source/dmltad/diag.c
++++ b/source/dmltad/diag.c
+@@ -496,7 +496,7 @@ static void *diag_task(void *arg)
+             break;
+     }
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_) || (_PLATFORM_TURRIS_)
++#if defined(_PLATFORM_RASPBERRYPI_) || (_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+ /**
+  inet_pton is failing because of extra quotes in ip address (cfg.host)
+ **/
+-- 
+2.47.0
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/test-and-diagnostic.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/test-and-diagnostic.bbappend
@@ -1,1 +1,14 @@
 include recipes-ccsp/ccsp/ccsp_common_bananapi.inc
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
+
+SRC_URI_append += " \
+    file://BPI-TestAndDiagnostic-changes.patch;apply=no \
+"
+do_bananapi_patches() {
+    cd ${S}
+    if [ ! -e bananapi_patch_applied ]; then
+        patch -p1 < ${WORKDIR}/BPI-TestAndDiagnostic-changes.patch
+        touch bananapi_patch_applied
+    fi
+}
+addtask bananapi_patches after do_unpack before do_configure

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -42,4 +42,7 @@ fi
 \$T2Enable=true
 \$T2Version=2.0.1
 \$T2ConfigURL=https://xconf.rdkcentral.com:19092/loguploader/getT2Settings"  >> ${D}${sysconfdir}/utopia/system_defaults
+
+#lan0 is used for WAN connection
+sed -i "s/\$\$lan_ethernet_physical_ifnames=lan0 lan1 lan2 lan3 lan4/\$\$lan_ethernet_physical_ifnames=lan1 lan2 lan3 lan4/g" ${D}${sysconfdir}/utopia/system_defaults
 }

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/0002-fix-swctl-missing-api.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/0002-fix-swctl-missing-api.patch
@@ -1,0 +1,13 @@
+diff --git a/source/service_multinet/Puma6_plat/handle_sw.c b/source/service_multinet/Puma6_plat/handle_sw.c
+index f67ae3fc..f7acb772 100755
+--- a/source/service_multinet/Puma6_plat/handle_sw.c
++++ b/source/service_multinet/Puma6_plat/handle_sw.c
+@@ -90,6 +90,8 @@ void sw_remove_member(char *from_member, char *to_remove_mem)
+        strncpy(from_member, l_cTemp, (strlen(l_cTemp)+1));
+ }
+
++INT swctl(const int command, const int port, const int vid, const int membertag, const int vlanmode, const int efm, const char *mac, const char *magic){return 0;}
++
+ #if !defined (NO_MOCA_FEATURE_SUPPORT)
+ //handle_moca is a function for configuring MOCA port
+ void handle_moca(int vlan_id, int *tagged, int add)

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -38,3 +38,12 @@ fi
 
 # default BSP layer is meta-cmf-bananapi for B-PI builds
 export RDK_BSP_LAYER=meta-cmf-bananapi
+
+if [ ! -e ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia_changes_applied ]; then
+sed -i '19 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
+sed -i '39 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
+sed -i '40 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
+mv ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia/0002-fix-swctl-missing-api.patch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia/0002-fix-swctl-missing-api_old.patch
+touch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia_changes_applied
+fi
+


### PR DESCRIPTION

Reason for change:  lan0 interfaces is used for WAN connection in bpi4. so we need to remove that interface form ethernet members lists. Also, addressed webui login issue
Test Procedure: erouter0 interface is getting IPv4 address every boot and Able to login WebUI successfully after multiple reboots Risks: Low