### PR TITLE
RDKBACCL-470, RDKBACCL-471 : erouter0 interface is not getting ip addr…

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/bpi_serial_no_fix.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/bpi_serial_no_fix.patch
@@ -1,0 +1,27 @@
+--- a/rdkb_hal/src/platform/platform_hal_o.c	2024-10-25 05:55:10.854662219 +0000
++++ b/rdkb_hal/src/platform/platform_hal.c	2024-10-25 05:56:52.705396106 +0000
+@@ -106,7 +106,8 @@
+ 	if (pValue != NULL)
+ 	{
+ 		INT arr[6] = {0};
+-		const char *path = "/sys/class/net/eth1/address";
++		const char *path = "/etc/machine-id";
++		//const char *path = "/sys/class/net/eth1/address";
+ 		FILE *fp = fopen(path, "r");
+ 		if (fp != NULL)
+ 		{
+@@ -114,11 +115,12 @@
+ 			char buf[64] = {0};
+ 			fgets(buf, sizeof(buf), fp);
+ 			fclose(fp);
+-			if(6  == sscanf(buf, "%02x:%02x:%02x:%02x:%02x:%02x",&arr[0],&arr[1],&arr[2],&arr[3],&arr[4],&arr[5]))
++			sprintf(pValue,"%s",buf);
++			/*if(6  == sscanf(buf, "%02x:%02x:%02x:%02x:%02x:%02x",&arr[0],&arr[1],&arr[2],&arr[3],&arr[4],&arr[5]))
+ 			{
+ 				sprintf(pValue,"%02x%02x%02x%02x%02x%02x",arr[0],arr[1],arr[2],arr[3],arr[4],arr[5]);
+ 				return RETURN_OK;
+-			}	
++			}*/
+ 		}
+ 	}
+ 	return RETURN_ERR;

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-platform-generic_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-platform-generic_git.bbappend
@@ -1,6 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI_append += "file://Add_ipv6_changes.patch"
+SRC_URI += " file://Add_ipv6_changes.patch"
+SRC_URI += " file://bpi_serial_no_fix.patch"
+
 do_configure_append() {
      #For trimming the spaces
      sed -i "s/cat \/proc\/device-tree\/model/cat \/proc\/device-tree\/model | tr -d ' '/g" ${S}/rdkb_hal/src/platform/platform_hal.c

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -42,4 +42,6 @@ fi
 \$T2Enable=true
 \$T2Version=2.0.1
 \$T2ConfigURL=https://xconf.rdkcentral.com:19092/loguploader/getT2Settings"  >> ${D}${sysconfdir}/utopia/system_defaults
+
+sed -i "s/\$\$lan_ethernet_physical_ifnames=lan0 lan1 lan2 lan3 lan4/\$\$lan_ethernet_physical_ifnames=lan1 lan2 lan3 lan4/g" ${D}${sysconfdir}/utopia/system_defaults
 }


### PR DESCRIPTION
…ess intermittently

Reason for change:  lan0 interfaces is used for WAN connection in bpi4. so we need to remove that interface form ethernet members lists. Also, addressed webui login issue
Test Procedure: erouter0 interface is getting IPv4 address every boot and Able to login WebUI successfully after multiple reboots Risks: Low