### PR TITLE
RDKBACCL-297 crash upload support

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-common/crashupload/crashupload_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-common/crashupload/crashupload_git.bbappend
@@ -1,0 +1,5 @@
+
+do_install_append () {
+	sed -i '/After=network-online.target/d' ${D}${systemd_unitdir}/system/coredump-upload.path
+	sed -i '/Requires=network-online.target/d' ${D}${systemd_unitdir}/system/coredump-upload.path
+}


### PR DESCRIPTION
crash upload support : Removed the Required and After: lines in the coredump-upload.path as it is causing circular dependency only in BPI platform