### PR TITLE
RDKBACCL-404 : Bringup onewifi in BPIR4 Reference platform

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start.sh
@@ -1,6 +1,32 @@
 #!/bin/sh
-
+sleep 5
 iw phy phy0 interface add wifi0 type __ap
-iw phy phy1 interface add wifi1 type __ap
+iw phy phy0 interface add wifi1 type __ap
+#iw phy phy0 interface add wifi2 type __ap
+
+#Obtain the wifi0 mac address
+wifi0_mac="$(cat /sys/class/ieee80211/phy0/macaddress)"
+#Strip the : and increment mac by 1 to get wifi1 macaddress
+mac=$(echo $wifi0_mac | tr -d ':')
+mac_incr=$((0x$mac + 1))
+wifi1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment again by 1 to get wifi2 address
+mac_incr=$(($mac_incr + 1))
+wifi2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#print the mac address
+echo $wifi0_mac
+echo $wifi1_mac
+#echo $wifi2_mac
+
+#Update the mac address using ip link command
+ifconfig wifi0 down
+ifconfig wifi1 down
+#ifconfig wifi2 down
+ip link set dev wifi0 address $wifi0_mac
+ip link set dev wifi1 address $wifi1_mac
+#ip link set dev wifi2 address $wifi2_mac
+ifconfig wifi0 up
+ifconfig wifi1 up
+#ifconfig wifi2 up
 
 exit 0

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap.json
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap.json
@@ -1,0 +1,134 @@
+{
+    "PhyList": [
+        {
+            "Index": 0,
+            "RadioList": [
+                {
+                    "Index": 1,
+                    "RadioName": "wifi1",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wifi15",
+                            "Bridge": "brlan2",
+                            "vlanId": 0,
+                            "vapIndex": 15,
+                            "vapName": "mesh_sta_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi13",
+                            "Bridge": "brlan3",
+                            "vlanId": 0,
+                            "vapIndex": 13,
+                            "vapName": "mesh_backhaul_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi11",
+                            "Bridge": "br1an6",
+                            "vlanId": 0,
+                            "vapIndex": 11,
+                            "vapName": "lnf_radius_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi9",
+                            "Bridge": "brlan5",
+                            "vlanId": 0,
+                            "vapIndex": 9,
+                            "vapName": "hotspot_secure_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi7",
+                            "Bridge": "brlan6",
+                            "vlanId": 0,
+                            "vapIndex": 7,
+                            "vapName": "lnf_psk_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi5",
+                            "Bridge": "brlan3",
+                            "vlanId": 0,
+                            "vapIndex": 5,
+                            "vapName": "hotspot_open_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi3",
+                            "Bridge": "brlan1",
+                            "vlanId": 0,
+                            "vapIndex": 3,
+                            "vapName": "iot_ssid_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi1",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 1,
+                            "vapName": "private_ssid_5g"
+                        }
+                        
+                    ]
+                },
+                {
+                    "Index": 0,
+                    "RadioName": "wifi0",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wifi14",
+                            "Bridge": "brlan2",
+                            "vlanId": 0,
+                            "vapIndex": 14,
+                            "vapName": "mesh_sta_2g"
+                        },
+                        {
+                            "InterfaceName": "wifi12",
+                            "Bridge": "brlan2",
+                            "vlanId": 0,
+                            "vapIndex": 12,
+                            "vapName": "mesh_backhaul_2g"
+                        },
+                        {
+                            "InterfaceName": "wifi10",
+                            "Bridge": "brlan6",
+                            "vlanId": 0,
+                            "vapIndex": 10,
+                            "vapName": "lnf_radius_2g"
+                        },
+                        {
+                            "InterfaceName": "wifi8",
+                            "Bridge": "brlan4",
+                            "vlanId": 0,
+                            "vapIndex": 8,
+                            "vapName": "hotspot_secure_2g"
+                        },
+                        {
+                            "InterfaceName": "wifi6",
+                            "Bridge": "brlan6",
+                            "vlanId": 0,
+                            "vapIndex": 6,
+                            "vapName": "lnf_psk_2g"
+                        },
+                        {
+                            "InterfaceName": "wifi4",
+                            "Bridge": "brlan2",
+                            "vlanId": 0,
+                            "vapIndex": 4,
+                            "vapName": "hotspot_open_2g"
+                        },
+                        {
+                            "InterfaceName": "wifi2",
+                            "Bridge": "brlan1",
+                            "vlanId": 0,
+                            "vapIndex": 2,
+                            "vapName": "iot_ssid_2g"
+                        },
+                        {
+                            "InterfaceName": "wifi0",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 0,
+                            "vapName": "private_ssid_2g"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,4 +1,20 @@
-CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT "
+CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY "
 CFLAGS_append_kirkstone = " -fcommon"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' ONE_WIFIBUILD=true ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' BANANA_PI_PORT=true ', '', d)}"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+  file://InterfaceMap.json \
+"
+
+# Install InterfaceMap.json in /nvram
+do_install_append() {
+  install -d ${D}/nvram
+  install -m 0644 ${WORKDIR}/InterfaceMap.json ${D}/nvram/InterfaceMap.json
+}
+
+FILES_${PN} += " \
+  /nvram/InterfaceMap.json \
+"


### PR DESCRIPTION
Reason for change: Added dual band changes for onewifi bring up in bpi
Test Procedure: wifi sanity test cases(2G,5G) are passed.
Risks: Low