### PR TITLE
RDKBACCL-515 : CaptivePortal page is not loading in connected clients

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -32,3 +32,5 @@ DISTRO_FEATURES_append = " rdkb_cellular_manager_mm"
 
 #Dac Feature support for BPIR4 device.
 DISTRO_FEATURES_append = " dac"
+
+DISTRO_FEATURES_append = " partner_default_ext"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -46,6 +46,14 @@ do_install_append_class-target() {
 
    #SNMP SUPPORT
    sed -i "/tcp\:192.168.254.253\:705/a  ExecStart=\/usr\/bin\/snmp_subagent \&" ${D}${systemd_unitdir}/system/snmpSubAgent.service
+  
+   if ${@bb.utils.contains('DISTRO_FEATURES', 'partner_default_ext', 'true', 'false', d)}; then
+       sed -i "/^After=.*/a Requires=ApplySystemDefaults.service " ${D}${systemd_unitdir}/system/CcspPandMSsp.service
+       if [ $DISTRO_OneWiFi_ENABLED = 'true' ]; then
+           sed -i "/^After=/ s/$/ ApplySystemDefaults.service /g" ${D}${systemd_unitdir}/system/RdkWanManager.service
+           sed -i "/^After=/ s/$/ ApplySystemDefaults.service /g" ${D}${systemd_unitdir}/system/RdkVlanManager.service
+       fi
+    fi 
 }
 
 


### PR DESCRIPTION
Reason for change:  Enabled distro for partners apply defaults and added required changes in ccsp common library for addressing this issue in bpi platform.
Test Procedure: Captiveportal page is loading properly with fresh boot and FR 
Risks: Low