### PR TITLE
RDKBACCL-526 : Need to check the populate_sdk build in BPI Platform

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-connectivity/dibbler/dibbler_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/dibbler/dibbler_git.bbappend
@@ -1,0 +1,6 @@
+#To avoid multiple installation
+do_install_append() {
+        if [ -f ${D}${sysconfdir}/udhcpc.vendor_specific ]; then
+                rm -rf ${D}${sysconfdir}/udhcpc.vendor_specific
+        fi
+}

--- a/meta-rdk-mtk-bpir4/recipes-core/glibc/glibc-locale_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/glibc/glibc-locale_%.bbappend
@@ -1,0 +1,6 @@
+#To avoid do_package_qa issue for files not shipped but installed.
+do_install_append() {
+        # Remove empty dirs in libdir when gconv or locales are not copied
+        find ${D}${libdir} -type d -empty -delete
+}
+


### PR DESCRIPTION
Reason for change : Fixed below SDK errors,
~ERROR: glibc-locale-2.35-r0 do_package: QA Issue: glibc-locale: Files/directories were installed but not shipped in any package: /usr/lib/locale Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install. glibc-locale: 1 installed and not shipped files. [installed-vs-shipped]
~Downloading file:/home/jenkins/jenkinsroot/workspace/bpi-dec16/build-bananapi4-rdk-broadband/tmp/work/bananapi4_rdk_broadband-rdk-linux/rdk-generic-broadband * check_data_file_clashes: Package dibbler wants to install file /home/jenkins/jenkinsroot/workspace/bpi-dec16/build-bananapi4-rdk-broadband/tmp/work/bananapi4_rdk_broadband-rdk-linux/rdk-generic-broadband-image/1.0-r0/sdk/image/opt/rdk/2.0/sysroots/cortexa53-rdk-linux/etc/udhcpc.vendor_specific But that file is already provided by package  * utopia
 Test Procedure: Able to trigger sdk build and followed https://wiki.rdkcentral.com/display/RDK/Creating+Yocto+SDK to test the project
  Risks: Low