### PR TITLE
RDKBACCL-527 : Need to check the populate_sdk_ext build in BPI Platform

### DIFF
--- a/conf/include/rdk-bpi-bbmasks.inc
+++ b/conf/include/rdk-bpi-bbmasks.inc
@@ -3,3 +3,7 @@ BBMASK .= "|meta-cmf-filogic/recipes-extended/tdkb/"
 BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '|meta-filogic/recipes-wifi/hostapd/', '', d)}"
 BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '|meta-filogic/recipes-wifi/hal/halinterface.bbappend', '', d)}"
 BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '|meta-cmf-filogic/recipes-common/mesh-agent/mesh-agent.bbappend', '', d)}"
+
+BBMASK_append_kirkstone .= "|meta-rdk-opensync/recipes/python3-jinja2/python3-jinja2_2.11.1.bb"
+BBMASK .= "|meta-cmf/recipes-core/images/rdk-ipstb-oss-image.bb"
+BBMASK .= "|meta-cmf/recipes-core/images/rdk-ipstb-oss-tdk-image.bb"

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -9,6 +9,9 @@ do_build[depends] += "${@bb.utils.contains('DISTRO_FEATURES','sdmmc','atf_bootlo
 
 ROOTFS_POSTPROCESS_COMMAND_append = "add_busybox_fixes; "
 
+#Emptying the PRSERV_HOST since builds are local
+PRSERV_HOST = ""
+
 add_busybox_fixes() {
                 if [  -d ${IMAGE_ROOTFS}/bin ]; then
                         cd ${IMAGE_ROOTFS}/bin/ 

--- a/meta-rdk-mtk-bpir4/recipes-devtools/init-filogic/init-filogic.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-devtools/init-filogic/init-filogic.bbappend
@@ -7,3 +7,9 @@ if [ ! -d /nvram/secure ]; then \
     mkdir -p /nvram/secure \
 fi' ${D}${sbindir}/init-bridge.sh
 }
+
+#ESDK support - Avoid conflict file is installed by both systemd and init-filogic in kirkstone
+SYSTEMD_SERVICE:${PN}_remove = "usb-mount@.service"
+do_install_append_broadband () {
+   rm ${D}${systemd_unitdir}/system/usb-mount@.service
+}


### PR DESCRIPTION
Reason for change : Fixed below ESDK errors,
1. ERROR: nativesdk-python3-jinja2-2.11.1-r0 do_fetch: Bitbake Fetcher Error: FetchError('Unable to fetch URL from any source.', 'https://files.pythonhosted.org/packages/source/j/jinja2/jinja2-2.11.1.tar.gz')
2. rdk-generic-broadband-image-1.0-r0 do_sdk_depends: The file /lib/systemd/system/usb-mount@.service is installed by both systemd and init-filogic, aborting
3. failed with exit code '1'ERROR: init-filogic-1.0-r0 do_package: Didn't find service unit 'usb-mount@.service', specified in SYSTEMD_SERVICE:init-filogic. Also looked for service unit 'usb-mount@.service'.
4. ERROR: rdk-generic-broadband-image-1.0-r0 do_populate_sdk_ext: Connecting to PR service localhost:0 failed: 'NoneType' object has no attribute 'port'
5. rdk_sdk/layers/meta-cmf/recipes-core/images/rdk-ipstb-oss-image.bb:9: Could not include required file ${RDKROOT}/meta-rdk/recipes-core/images/sdk-common.inc
Test Procedure: Tested the esdk script devtool
Risks: Low