### PR TITLE
RDKBACCL-531:Resolve opensync fetch error.

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-opensync/opensync/opensync_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-opensync/opensync/opensync_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-OPENSYNC_VENDOR_URI = "git://git@github.com/rdkcentral/opensync-vendor-rdk-rpi.git;protocol=${CMF_GIT_PROTOCOL};branch=main;name=vendor;destsuffix=git/vendor/rpi"
+OPENSYNC_VENDOR_URI = "git://github.com/rdkcentral/opensync-vendor-rdk-rpi.git;protocol=${CMF_GIT_PROTOCOL};branch=main;name=vendor;destsuffix=git/vendor/rpi"
 OPENSYNC_VENDOR_URI += "file://updated_vendor_arch_to_support_bpi.patch;patchdir=../vendor/rpi"
 
 DEPENDS_append = " rdk-logger"


### PR DESCRIPTION
Reason for change:Remove git protocol from opensync-headers recipe. 
Test Procedure: BPIR4 build should pass.
Risks:Low