### PR TITLE
RDKBACCL-468 : Added fix for utopia build issue

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -1,6 +1,6 @@
 include meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp_common_bananapi.inc
 
-
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 do_install_append() {
 
 install -d ${D}${sysconfdir}/

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/0002-fix-swctl-missing-api.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/0002-fix-swctl-missing-api.patch
@@ -1,0 +1,12 @@
+diff --git a/source/service_multinet/Puma6_plat/handle_sw.c b/source/service_multinet/Puma6_plat/handle_sw.c
+index f67ae3fc..f7acb772 100755
+--- a/source/service_multinet/Puma6_plat/handle_sw.c
++++ b/source/service_multinet/Puma6_plat/handle_sw.c
+@@ -90,6 +90,8 @@ void sw_remove_member(char *from_member, char *to_remove_mem)
+        strncpy(from_member, l_cTemp, (strlen(l_cTemp)+1));
+ }
++INT swctl(const int command, const int port, const int vid, const int membertag, const int vlanmode, const int efm, const char *mac, const char *magic){return 0;}
++
+ #if !defined (NO_MOCA_FEATURE_SUPPORT)
+ //handle_moca is a function for configuring MOCA port
+ void handle_moca(int vlan_id, int *tagged, int add)

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -44,3 +44,11 @@ export RDK_BSP_LAYER=meta-cmf-bananapi
 if [ "X$BPI_IMG_TYPE" != "X" ]; then
     echo "DISTRO_FEATURES_append =\" $BPI_IMG_TYPE\"" >> conf/local.conf
 fi
+
+if [ ! -e ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia_changes_applied ]; then
+sed -i '19 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
+sed -i '39 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
+sed -i '40 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
+mv ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia/0002-fix-swctl-missing-api.patch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia/0002-fix-swctl-missing-api_old.patch
+touch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia_changes_applied
+fi


### PR DESCRIPTION
Reason for change: Observing utopia patch failure in recent bpi builds. Added fix for the same.
Test Procedure: Build successfull
Risks: Low