### PR TITLE
RDKBACCL-504: Automate SD Monolithic image generation for BPIR4

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -34,3 +34,6 @@ DISTRO_FEATURES_append = " rdkb_cellular_manager_mm"
 DISTRO_FEATURES_append = " dac"
 
 DISTRO_FEATURES_append = " partner_default_ext"
+
+#NAND image is default image. Uncomment the following line for SDcard image
+#DISTRO_FEATURES_append = " sdmmc"

--- a/conf/machine/bananapi4-rdk-broadband.conf
+++ b/conf/machine/bananapi4-rdk-broadband.conf
@@ -11,5 +11,11 @@ PREFERRED_PROVIDER_hal-wifi_onewifi = "hal-wifi-generic"
 
 #SDCARD supported changes.
 MACHINEOVERRIDES .="${@bb.utils.contains('DISTRO_FEATURES','sdmmc',':sd','',d)}"
-IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES','sdmmc','ext4','',d)}"
+IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES','sdmmc',' wic.bz2 ext4','',d)}"
 KERNEL_DEVICETREE_mt7988_bpi4_sd = "mediatek/mt7988a-bananapi-bpi-r4-sd.dtb"
+
+WKS_FILE = " sdimage-Bananapi.wks"
+IMAGE_BOOT_FILES = "${@bb.utils.contains('DISTRO_FEATURES','sdmmc','mt7988a-bananapi-bpi-r4-sd.dtb ${KERNEL_IMAGETYPE}','',d)}"
+do_image_wic[recrdeps] = "do_build"
+#SDCARD supported Pre build bootloader
+do_image_wic[depends] += " atf_bootloader_prebuild:do_deploy"

--- a/meta-rdk-mtk-bpir4/recipes-bsp/trusted-firmware-a/bootloader_prebuild.bb
+++ b/meta-rdk-mtk-bpir4/recipes-bsp/trusted-firmware-a/bootloader_prebuild.bb
@@ -17,19 +17,20 @@ do_configure[noexec] = "1"
 # since there is no 'main' package generated (empty)
 RDEPENDS_${PN}-dev = ""
 
-SRC_URI = "https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_bl2.img;name=bl2\
-           https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_fip.bin;name=fip\
-           https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpir4_sd_image_creater.sh;name=sdimg\
+SRC_URI = "https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_bl2.img;name=bl2 \
+           https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_fip.bin;name=fip \
           "
 
 SRC_URI[bl2.sha256sum]= "7af8092bc993241f44013c28894739ceb9bdb93bab593d15cc10e2e68e57a349"
 SRC_URI[fip.sha256sum] = "e32aa5b1d5aca78765703f8544386fb6c294385ae120c272a863d46a599339e3"
-SRC_URI[sdimg.sha256sum] = "d6747c81c8330b4f37bae34fdff1480c548f3bbe5f3fa41536907d97df89bc83"
+
+# Alternative SRC_URI using local files - uncomment below 2 lines and comment above SRC_URI and checksums
+#SRC_URI = “file://bpi-r4_sdmmc_bl2.img \
+#           file://bpi-r4_sdmmc_fip.bin "
 
 do_deploy() {
         mkdir -p ${DEPLOYDIR}/atf/
         install -m 0644 ${WORKDIR}/bpi-r4_sdmmc_bl2.img ${DEPLOYDIR}/atf/
         install -m 0644 ${WORKDIR}/bpi-r4_sdmmc_fip.bin ${DEPLOYDIR}/atf/
-        install -m 0777 ${WORKDIR}/bpir4_sd_image_creater.sh ${DEPLOYDIR}/
 }
 addtask do_deploy after do_install

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -4,9 +4,6 @@ IMAGE_INSTALL_append = " parodus parodus2ccsp"
 #TR069 Feature
 IMAGE_INSTALL_append = " ccsp-tr069-pa"
 
-#SDCARD supported Pre build bootloader
-do_build[depends] += "${@bb.utils.contains('DISTRO_FEATURES','sdmmc','atf_bootloader_prebuild:do_deploy','',d)}"
-
 ROOTFS_POSTPROCESS_COMMAND_append = "add_busybox_fixes; "
 
 #Emptying the PRSERV_HOST since builds are local

--- a/wic/sdimage-Bananapi.wks
+++ b/wic/sdimage-Bananapi.wks
@@ -1,0 +1,12 @@
+# short-description: Create Bananapi Pi SD card image
+# long-description: Creates a partitioned SD card image for use with Bananapi R4.
+
+bootloader --ptable gpt --timeout=0
+
+part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2.img" --part-name bl2 --align 17 --fixed-size 4079K --active --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+
+part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip.bin" --part-name fip --align 6656 --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 8704 --fixed-size 100M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 111104


### PR DESCRIPTION
Reason for change: Create wic.bz image for BPIR4 through Yocto build Test procedure: Validate wic.bz image ie produced through yocto build in BPIR4 target
Risks: Low