### PR TITLE
RDKBACCL-548 : Observing utopia build issue in latest builds

### DIFF
--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -49,6 +49,9 @@ if [ ! -e ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia_changes_applied ]
 sed -i '19 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
 sed -i '39 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
 sed -i '40 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
-mv ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia/0002-fix-swctl-missing-api.patch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia/0002-fix-swctl-missing-api_old.patch
+sed -i '8 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
+sed -i '42 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
+sed -i '43 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
+sed -i '21 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
 touch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia_changes_applied
 fi


### PR DESCRIPTION
Reason for change:  This error is observing due to below line EXTRA_OECONF_remove  = "--with-ccsp-platform=bcm" removal in meta-cmf-filogic . This oeconf is needed for ref platforms and corresponding patch file (0002-fix-swctl-missing-api.patch)also not needed now. 
Test Procedure: bitbake utopia should be successful 
Risks: Low