### PR TITLE
RDKBACCL-582 : Enable sdmmc distro by default for BPI-r4 images

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -35,5 +35,5 @@ DISTRO_FEATURES_append = " dac"
 
 DISTRO_FEATURES_append = " partner_default_ext"
 
-#NAND image is default image. Uncomment the following line for SDcard image
-#DISTRO_FEATURES_append = " sdmmc"
+#Enable SDcard image as default
+DISTRO_FEATURES_append = " sdmmc"

--- a/meta-rdk-mtk-bpir4/recipes-bsp/trusted-firmware-a/bootloader_prebuild.bb
+++ b/meta-rdk-mtk-bpir4/recipes-bsp/trusted-firmware-a/bootloader_prebuild.bb
@@ -24,7 +24,8 @@ SRC_URI = "https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/u
 SRC_URI[bl2.sha256sum]= "7af8092bc993241f44013c28894739ceb9bdb93bab593d15cc10e2e68e57a349"
 SRC_URI[fip.sha256sum] = "e32aa5b1d5aca78765703f8544386fb6c294385ae120c272a863d46a599339e3"
 
-# Alternative SRC_URI using local files - uncomment below 2 lines and comment above SRC_URI and checksums
+# Alternative SRC_URI using local files - uncomment below 3 lines and comment above SRC_URI and checksums
+#FILESEXTRAPATHS_append := "${THISDIR}/files:"
 #SRC_URI = "file://bpi-r4_sdmmc_bl2.img \
 #           file://bpi-r4_sdmmc_fip.bin "
 

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -41,8 +41,10 @@ export RDK_BSP_LAYER=meta-cmf-bananapi
 
 
 # Enabling distro features as part of the build
-if [ "X$BPI_IMG_TYPE" != "X" ]; then
+if [ "X$BPI_IMG_TYPE" == "Xsdmmc" ]; then
     echo "DISTRO_FEATURES_append =\" $BPI_IMG_TYPE\"" >> conf/local.conf
+elif [ "X$BPI_IMG_TYPE" == "Xnand" ]; then
+    sed -i '/sdmmc/s/^/#/' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
 fi
 
 if [ ! -e ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia_changes_applied ]; then


### PR DESCRIPTION
Reason for change: Enabling sdmmc distro to create wic.bz2 images for BPI-R4
Test procedure: Validate wic.bz image ie produced through yocto build in BPIR4 target
Risks: Low