### PR TITLE
RDKBACCL-562 : 6G info is not populated in WebUi

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-webui-jst.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-webui-jst.bbappend
@@ -4,6 +4,7 @@ do_install_append () {
                 if ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'true', 'false', d)}; then
                    install -m 0755 ${S}/../xb6/jst/wireless_network_configuration_onewifi.jst ${D}/usr/www2/wireless_network_configuration.jst
                    install -m 0755 ${S}/../xb6/jst/wireless_network_configuration_edit_onewifi.jst ${D}/usr/www2/wireless_network_configuration_edit.jst
+                   install -m 0755 ${S}/../xb6/jst/at_a_glance.jst ${D}/usr/www2/at_a_glance.jst
                    install -m 0755 ${S}/../xb6/jst/actionHandler/ajaxSet_wireless_network_configuration_onewifi.jst ${D}/usr/www2/actionHandler/ajaxSet_wireless_network_configuration.jst
                    install -m 0755 ${S}/../xb6/jst/actionHandler/ajaxSet_wireless_network_configuration_edit_onewifi.jst ${D}/usr/www2/actionHandler/ajaxSet_wireless_network_configuration_edit.jst
                    install -m 0755 ${S}/jst/actionHandler/ajaxSet_wireless_network_configuration_redirection_onewifi.jst ${D}/usr/www2/actionHandler/ajaxSet_wireless_network_configuration_redirection.jst


### PR DESCRIPTION
Reason for change: Added required codes changes as per the XB devices
Test Procedure: Able to see 6G info in WebUI.
Screenshot attached in JIRA
Risks: Low