### PR TITLE
RDKBACCL-596: Dynamically update uboot artifact url in BPI R4

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-bsp/trusted-firmware-a/bootloader_prebuild.bb
+++ b/meta-rdk-mtk-bpir4/recipes-bsp/trusted-firmware-a/bootloader_prebuild.bb
@@ -17,17 +17,8 @@ do_configure[noexec] = "1"
 # since there is no 'main' package generated (empty)
 RDEPENDS_${PN}-dev = ""
 
-SRC_URI = "https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_bl2.img;name=bl2 \
-           https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_fip.bin;name=fip \
-          "
-
-SRC_URI[bl2.sha256sum]= "7af8092bc993241f44013c28894739ceb9bdb93bab593d15cc10e2e68e57a349"
-SRC_URI[fip.sha256sum] = "e32aa5b1d5aca78765703f8544386fb6c294385ae120c272a863d46a599339e3"
-
-# Alternative SRC_URI using local files - uncomment below 3 lines and comment above SRC_URI and checksums
-#FILESEXTRAPATHS_append := "${THISDIR}/files:"
-#SRC_URI = "file://bpi-r4_sdmmc_bl2.img \
-#           file://bpi-r4_sdmmc_fip.bin "
+SRC_URI_append += " file://bpi-r4_sdmmc_bl2.img \
+                    file://bpi-r4_sdmmc_fip.bin"
 
 do_deploy() {
         mkdir -p ${DEPLOYDIR}/atf/

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -39,12 +39,22 @@ fi
 # default BSP layer is meta-cmf-bananapi for B-PI builds
 export RDK_BSP_LAYER=meta-cmf-bananapi
 
-
-# Enabling distro features as part of the build
-if [ "X$BPI_IMG_TYPE" == "Xsdmmc" ]; then
-    echo "DISTRO_FEATURES_append =\" $BPI_IMG_TYPE\"" >> conf/local.conf
-elif [ "X$BPI_IMG_TYPE" == "Xnand" ]; then
+if [ "X$BPI_IMG_TYPE" == "Xnand" ]; then
     sed -i '/sdmmc/s/^/#/' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
+else # SD card image is default
+    mkdir -p ${_TOPDIR}/downloads
+    if [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_bl2.img ] && [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_fip.bin ]; then
+        echo "Both bl2 and fip binaries are present in local workspace."
+    else
+        echo "**********************************************************************"
+        echo "> CAUTION: YOU ARE TRYING TO BUILD SD CARD IMAGE WITHOUT BL2 AND FIP BINARIES."
+        echo "> Please download the binaries from https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_bl2.img and https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_fip.bin"
+        echo "> If you don't have access to above resources, please follow instruction in https://wiki.rdkcentral.com/pages/viewpage.action?pageId=354648448#SDMonoliticimagebuildandflashingstepsforBPIR4.-Buildingbl2.imgandfip.binincaseofnothavingaccesstoartifactoryrepository to build bl2 and fip binaries yourselves."
+        echo "> Place those binaries under ${_TOPDIR}/downloads/"
+        echo "> EXITING NOW."
+        echo "**********************************************************************"
+        exit 1
+    fi
 fi
 
 if [ ! -e ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia_changes_applied ]; then


### PR DESCRIPTION
Reason for change: Avoid updation in recipe
Test procedure: Building SD card image with & without access to artifactory
Risks: Low