### PR TITLE
RDKBACCL-615: Added required changes in utopia from beta to develop

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -2,7 +2,23 @@ include meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp_common_bananapi.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://service_bridge_bpi.sh"
+SRC_URI += " file://service_bridge_bpi.sh"
+SRC_URI += " file://bridge_mode_support.patch;apply=no"
+SRC_URI += " file://brlan0_issue_fix.patch;apply=no"
+
+do_bpi_patches() {
+    cd ${S}
+    if [ ! -e bpi_patch_applied ]; then
+         bbnote "Patching bridge_mode_support.patch"
+         patch -p1 < ${WORKDIR}/bridge_mode_support.patch
+
+         bbnote "Patching brlan0_issue_fix.patch"
+         patch -p1 < ${WORKDIR}/brlan0_issue_fix.patch
+         touch bpi_patch_applied
+    fi
+}
+
+addtask bpi_patches after do_unpack before do_compile
 
 do_install_append() {
 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/bridge_mode_support.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/bridge_mode_support.patch
@@ -1,0 +1,30 @@
+From a1522dded07a7b77d209e04a990f6ad82fd3fc4c Mon Sep 17 00:00:00 2001
+From: Heam Kumar <hkumar343@cable.comcast.com>
+Date: Fri, 20 Dec 2024 12:15:15 +0530
+Subject: [PATCH] RDKBDEV-3082 RDKBACCL-313: Bridge Mode support in BPI R4.
+
+Reason for change:Bridge mode support for bpi4 platform.
+Test Procedure: Ethernet (lan) clients should get Public IP address(i,e in erouter ip series)
+Risks: Low
+
+Change-Id: Ib27dc8cc73b4478376a2ad10bdd874b181e37e6e
+---
+
+diff --git a/source/scripts/init/c_registration/02_bridge.c b/source/scripts/init/c_registration/02_bridge.c
+index 7fd2cee..38cb24a 100644
+--- a/source/scripts/init/c_registration/02_bridge.c
++++ b/source/scripts/init/c_registration/02_bridge.c
+@@ -53,9 +53,12 @@
+ #else
+ const char* SERVICE_CUSTOM_EVENTS[] = { NULL };
+ #endif
+-#elif defined (_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
++#elif defined (_PLATFORM_RASPBERRYPI_)
+ const char* SERVICE_DEFAULT_HANDLER = "/etc/utopia/service.d/service_bridge_rpi.sh";
+ const char* SERVICE_CUSTOM_EVENTS[] = { NULL };
++#elif defined (_PLATFORM_BANANAPI_R4_)
++const char* SERVICE_DEFAULT_HANDLER = "/etc/utopia/service.d/service_bridge_bpi.sh";
++const char* SERVICE_CUSTOM_EVENTS[] = { NULL };
+ #else
+ const char* SERVICE_DEFAULT_HANDLER = "/etc/utopia/service.d/service_bridge.sh";
+ const char* SERVICE_CUSTOM_EVENTS[] = { NULL };

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/brlan0_issue_fix.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/brlan0_issue_fix.patch
@@ -1,0 +1,22 @@
+Subject: [PATCH] RDKBDEV-3092: Avoid redundant code that picks parameters from /etc/device.properties
+
+Reason for change: Redundant code cleanup
+Risks: None
+
+Signed-off-by: sai satish kotapati  <skotapati@maxlinear.com>
+
+Change-Id: I1aa2cdfbd724cbaf8f99f2a7fedd611111e33177
+
+diff --git a/source/scripts/init/service.d/lan_handler.sh b/source/scripts/init/service.d/lan_handler.sh
+index e5ba1b33..7002165f 100755
+--- a/source/scripts/init/service.d/lan_handler.sh
++++ b/source/scripts/init/service.d/lan_handler.sh
+@@ -54,7 +54,7 @@ SERVICE_NAME="lan_handler"
+ 
+ POSTD_START_FILE="/tmp/.postd_started"
+ 
+-RPI_SPECIFIC=`grep -i "BOX_TYPE" /etc/device.properties  | cut -f2 -d=`
++RPI_SPECIFIC=$BOX_TYPE
+ #args: router IP, subnet mask
+ ap_addr() {
+     if [ "$2" ]; then


### PR DESCRIPTION
Reason for change: Added bridgemode and brlan0 IP issue fixes 
Test Procedure: Ethernet (lan) clients should get Public IP address(i,e in erouter ip series) and brlan0 gets ip accross all boots
Risks: Low