### PR TITLE
RDKBACCL-596: Returning from setup script instead of exiting

### DIFF
--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -53,7 +53,7 @@ else # SD card image is default
         echo "> Place those binaries under ${_TOPDIR}/downloads/"
         echo "> EXITING NOW."
         echo "**********************************************************************"
-        exit 1
+        return 1
     fi
 fi
 


### PR DESCRIPTION
Reason for change: Avoid coming out of build environment
Test procedure: Running setup environment script
Risks: None