### PR TITLE
RDKBACCL-631: Webpa get/set API is not working

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -7,7 +7,7 @@ SRCREV_FORMAT = "sysintgeneric_sysintdevicebpi"
 
 do_install_append () {
   #Webpa ServerURL
-  echo "SERVERURL=http://webpa.rdkcentral.com:8080" >> ${D}${sysconfdir}/device.properties
+  echo "SERVERURL=https://webpa.rdkcentral.com:8080" >> ${D}${sysconfdir}/device.properties
   echo "Box_Type=bpi" >> ${D}${sysconfdir}/device.properties
   ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'echo "OneWiFiEnabled=true" >> ${D}${sysconfdir}/device.properties', '', d)}
 


### PR DESCRIPTION
Reason for change: On server side, protocol is changed to https.
Test procedure: Check Get/Set with curl command
Risks: Low