### PR TITLE
RDKBACCL-632: Facing patch error ppp-support-for-vendor-LCP-req-or-connection-update.patch in BPI

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -37,3 +37,6 @@ DISTRO_FEATURES_append = " partner_default_ext"
 
 #Enable SDcard image as default
 DISTRO_FEATURES_append = " sdmmc"
+
+#PPP Feature
+#DISTRO_FEATURES_append = "ppp-enabled"

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -19,3 +19,5 @@ add_busybox_fixes() {
 			cd -
                 fi
 }
+
+IMAGE_INSTALL_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ppp-enabled', '', 'pptp-linux rp-pppoe xl2tpd', d)}"


### PR DESCRIPTION
Reason for change: Facing build issue in ppp, as currently we are not supporting ppp feature, removing its dependencies with distro.
Test Procedure: build should pass without ppp recipe error.
Risks: None.