### PR TITLE
REFPLTB-3395: New rdk-wifi-hal import change is not building

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
@@ -1,6 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_append = " file://Bpi_rdkwifilibhostap_changes.patch "
-SRC_URI_append = " file://mbssid_support.patch "
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_"


### PR DESCRIPTION
Reason for change:Respective mbssid patch came into meta-rdk-broadband layer, so removing from this layer to avoid patch already applied error. 
Test Procedure: Sanity.
Risks: None.