### PR TITLE
RDKBACCL-585 : Migration to the New BPI BSP "MP release"

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -40,3 +40,6 @@ DISTRO_FEATURES_append = " sdmmc"
 
 #PPP Feature
 #DISTRO_FEATURES_append = "ppp-enabled"
+
+#disabling lan0_as_wan to allow lan0 interface to come
+DISTRO_FEATURES_remove = " lan0_as_wan"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -6,6 +6,7 @@ SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protoc
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=OneWifi"
 SRCREV_OneWifi = "7d4697bc74017e0ec57c3ba903a70dfe56809cb4"
 DEPENDS_append = " mesh-agent "
+DEPENDS_remove = " opensync "
 
 CFLAGS_append = " -DWIFI_HAL_VERSION_3 -Wno-unused-function "
 LDFLAGS_append = " -ldl"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -5,6 +5,7 @@ SRCREV_rdk-wifi-hal = "51ce6f510012f1d3989bbe7141429498c9158d82"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY "
 CFLAGS_append_kirkstone = " -fcommon"
+CFLAGS_remove = "-DCONFIG_MBO"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' ONE_WIFIBUILD=true ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' BANANA_PI_PORT=true ', '', d)}"
 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
+SRC_URI_remove = " file://Rpi_rdkwifilibhostap_changes.patch"
+SRC_URI_remove = " file://fixed_6G_wrong_freq.patch"
 SRC_URI_append = " file://Bpi_rdkwifilibhostap_changes.patch "
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
@@ -2,4 +2,5 @@ RDEPENDS_packagegroup-filogic-mt76_remove_onewifi = " \
                     hostapd \
                     usteer \
                     wifi-test-tool \
+                    vts \
 "

--- a/meta-rdk-mtk-bpir4/recipes-netsys/eip-197/eip-197.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-netsys/eip-197/eip-197.bbappend
@@ -1,0 +1,2 @@
+SRC_URI_remove = "git://gerrit.mediatek.inc/openwrt/feeds/mtk_openwrt_feeds;protocol=https;branch=master;destsuffix=git"
+SRC_URI_append = " git://git01.mediatek.com/openwrt/feeds/mtk-openwrt-feeds;protocol=https;branch=master;destsuffix=git"

--- a/meta-rdk-mtk-bpir4/recipes-netsys/pce/pce.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-netsys/pce/pce.bbappend
@@ -1,0 +1,2 @@
+SRC_URI_remove = "git://gerrit.mediatek.inc/openwrt/feeds/mtk_openwrt_feeds;protocol=https;branch=master;destsuffix=git"
+SRC_URI_append = " git://git01.mediatek.com/openwrt/feeds/mtk-openwrt-feeds;protocol=https;branch=master;destsuffix=git"

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -77,3 +77,27 @@ sed -i '202 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappen
 sed -i '203 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappend
 touch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia_changes_applied
 fi
+
+if [ ! -e ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdkwifihal_changes_applied ]; then
+sed -i '9 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+sed -i '10 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+sed -i '11 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+sed -i '12 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+sed -i '13 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+sed -i '14 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+sed -i '15 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+sed -i '16 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+sed -i '17 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+touch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdkwifihal_changes_applied
+fi
+
+if [ ! -e ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/ccsp/onewifi_changes_applied ]; then
+sed -i 's/^SRC_URI +=/SRC_URI_append =/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+touch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/ccsp/onewifi_changes_applied
+fi
+
+# commenting removing dbus.service from meta-cmf-filogic
+if [ ! -e ${_TOPDIR}/meta-cmf-filogic/recipes-core/dbus/dbus_change ]; then
+sed -i '19 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-core/dbus/dbus_%.bbappend
+touch ${_TOPDIR}/meta-cmf-filogic/recipes-core/dbus/dbus_change
+fi


### PR DESCRIPTION
Reason for change: Fixing build and runtime issues after updating with meta-filogic and meta-cmf-filogic MP release
Test procedure: rdk-generic-broadband-image should pass the sanity test cases
Risks: Low