### PR TITLE
REFPLTB-3407 :New rdk-wifi-hal import change is not building

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/bpi_hostap_fix.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/bpi_hostap_fix.patch
@@ -1,0 +1,10 @@
+--- git/source/hostap-2.10/src/ap/ap_config.h
++++ git/source/hostap-2.10/src/ap/ap_config.h
+@@ -310,6 +310,7 @@
+ 	char *eap_sim_db;
+ 	unsigned int eap_sim_db_timeout;
+ 	int eap_server_erp; /* Whether ERP is enabled on internal EAP server */
++	struct hostapd_ip_addr own_ip_addr;
+ 	char *nas_identifier;
+ 	struct hostapd_radius_servers *radius;
+ 	int acct_interim_interval;

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
@@ -1,5 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI_append = " file://Bpi_rdkwifilibhostap_changes.patch "
+SRC_URI_append = " \
+                   file://Bpi_rdkwifilibhostap_changes.patch \
+                   file://bpi_hostap_fix.patch
+                 "
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_"


### PR DESCRIPTION
Reason for change: Facing struct hostapd_bss_config has no member named own_ip_addr, added in structure.
Test Procedure: Build should pass
Risks: Low