### PR TITLE
REFPLTB-3407 : New rdk-wifi-hal import change is not building

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/hal/rdk-wifi-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "51ce6f510012f1d3989bbe7141429498c9158d82"
+SRCREV_rdk-wifi-hal = "1232914fc172a2ba81997b983f68970c908eadaf"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY "
 CFLAGS_append_kirkstone = " -fcommon"
@@ -14,8 +14,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += " \
   file://InterfaceMap.json \
 "
-
-SRC_URI += " file://6g_interface_added_in_bridge.patch;patchdir=../"
 
 # Install InterfaceMap.json in /nvram
 do_install_append() {


### PR DESCRIPTION
Reason for change: Updated source revision to resolve the build errors, in the latest code base changes are available related to build error.
Test Procedure: Build should Pass and wifi sanity should be success
Risks: Low