### PR TITLE
RDKBACCL-672 : Added required changes in configure.ac and makefile.am to support EM

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -2,3 +2,12 @@ SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protoc
 
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=libwebconfig"
 SRCREV_libwebconfig = "7d4697bc74017e0ec57c3ba903a70dfe56809cb4"
+
+DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap unified-wifi-mesh-header ', '', d)}"
+EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-easymesh ', '', d)}"
+
+CFLAGS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -Wno-error=maybe-uninitialized -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=incompatible-pointer-types -Wno-error=sign-compare -Wno-error -DEASY_MESH_NODE -DEM_APP ', '', d)}"
+
+do_install_append() {
+      install -m 644 ${S}/include/webconfig_external_proto_easymesh.h  ${D}/usr/include/ccsp
+}

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/unified-wifi-mesh/unified-wifi-mesh-header.bb
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/unified-wifi-mesh/unified-wifi-mesh-header.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Unified-wifi-mesh header files installation"
+HOMEPAGE = "http://github.com/rdkcentral/unified-wifi-mesh"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e0b1ae637439c7d6f4487fb90163c79a"
+
+SRC_URI = "git://github.com/rdkcentral/unified-wifi-mesh.git;branch=main;protocol=https;name=Unified-wifi-mesh_header"
+PV = "git${SRCPV}"
+SRCREV_Unified-wifi-mesh_header = "${AUTOREV}"
+SRCREV_FORMAT = "Unified-wifi-mesh_header"
+S = "${WORKDIR}/git"
+
+do_install() {
+    install -d ${D}/usr/include/ccsp
+    install -m 644 ${S}/inc/*  ${D}/usr/include/ccsp
+}
+
+FILES_${PN} += "/usr/include/ccsp/* "


### PR DESCRIPTION
Reason for change:  EasyMesh integration in BPI
Test Procedure: Able to compile ccsp-one-wifi-libwebconfig with wifi_Easymesh_translator.c
Risks: Low