### PR TITLE
RDKBACCL-662 : Observing build issues intermittently

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/halinterface.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/halinterface.bbappend
@@ -12,4 +12,4 @@ do_hal_interface_patches() {
        touch patch_applied
     fi
 }
-addtask hal_interface_patches after do_unpack before do_compile
+addtask hal_interface_patches after do_unpack before do_configure


### PR DESCRIPTION
Reason for change:  executed the halinterface patch before configure tasks
Test Procedure: Able to compile rdk-wifi-hal
Risks: Low