### PR TITLE
RDKBACCL-712: Update hal_interface.patch file in meta-cmf-bananapi

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface.patch
@@ -6,65 +6,34 @@
 #Signed-off-by:Amalesh_Nandh@comcast.com
 ################################################
 diff --git a/wifi_hal_ap.h b/wifi_hal_ap.h
-index a5b1acf..704d5bd 100644
+index f5c37db..4453112 100644
 --- a/wifi_hal_ap.h
 +++ b/wifi_hal_ap.h
-@@ -1742,6 +1742,45 @@ void wifi_newApAssociatedDevice_callback_register(wifi_newApAssociatedDevice_cal
- * calls. It should probably just send a message to a driver event handler task.
- *
- */
-+typedef INT ( * wifi_stamode_callback)(int apIndex, char *mac, int key_mgmt, int type, int radio, int mode);
-+
-+/* wifi_hal_ap_max_client_rejection_callback_register() function */
-+/**
-+ * @brief This call back will be called whenever an authentication response with reject reason 17
-+ * is received.
-+ *
-+ * @param[in] apIndex          Access Point Index
-+ * @param[in] mac_address      client_mac_address
-+ * @param[in] reject_reason    reject reason
-+ *
-+ * @return The status of the operation
-+ * @retval RETURN_OK if successful
-+ * @retval RETURN_ERR if any error is detected
-+ *
-+ * @execution Synchronous
-+ * @sideeffect None
-+ *
-+ * @note This function must not suspend and must not invoke any blocking system
-+ * calls. It should probably just send a message to a driver event handler task.
-+ *
-+ */
-+typedef INT (*wifi_apMaxClientRejection_callback)(INT apIndex, char *MAC, INT reason);
-+
-+/**
-+ * @brief Callback function invoked when a RADIUS or EAP failure occurs.
-+ *
-+ * This callback function is invoked when a RADIUS or EAP failure occurs on
-+ * the specified Access Point (AP).
-+ * This function must not suspend and must not invoke any blocking system calls.
-+ *
-+ * @param[in] apIndex         Index of the Access Point.
-+ * @param[in] failure_reason  Reason for the failure.
-+ *
-+ * @returns The status of the operation.
-+ * @retval WIFI_HAL_SUCCESS If successful.
-+ * @retval WIFI_HAL_ERROR   If any error is detected.
-+ */
-+
- typedef INT ( * wifi_apDisassociatedDevice_callback)(INT apIndex, char *MAC, INT event_type);
+@@ -2736,6 +2736,14 @@ typedef struct {
+ } __attribute__((packed)) wifi_back_haul_sta_t;
  
- /* wifi_radiusEapFailure_callback() function */
-@@ -2700,6 +2739,8 @@ typedef struct {
-     mac_address_t bssid;                    /**< The BSSID. This variable should only be used in the get API. It can't used to change the interface MAC */
+ #define WIFI_AP_MAX_SSID_LEN    33
++/**
++ * @brief Maximum length of the vendor information elements buffer
++ *
++ * Not a standard value, but a reasonable maximum for vendor elements
++ * Computed by taking Max MPDU size - ~ MAX 802.11 header size - 802.11 FCS size - ~Size of required IEs
++ * 2,310 is divisible by the typical Vendor IE size (7 = IE Type[1] + IE Length[1] + OUI[3] + VIE Type[1] + VIE Subtype [1])
++ */
++#define WIFI_AP_MAX_VENDOR_IE_LEN 2310	
+ typedef struct {
+     CHAR    ssid[WIFI_AP_MAX_SSID_LEN];
+     BOOL    enabled;
+@@ -2763,6 +2771,8 @@ typedef struct {
      UINT   wmmNoAck;
      UINT   wepKeyLength;
-+    UINT   vendor_elements_len;
-+    UCHAR *vendor_elements;
      BOOL   bssHotspot;
++    UINT   vendor_elements_len;
++    UCHAR  vendor_elements[WIFI_AP_MAX_VENDOR_IE_LEN];
      UINT   wpsPushButton;
      char   beaconRateCtl[32];
-@@ -2857,4 +2898,4 @@ INT wifi_hal_analytics_callback_register(wifi_analytics_callback callback);
+     BOOL   network_initiated_greylist;
+@@ -2919,4 +2929,4 @@ INT wifi_hal_analytics_callback_register(wifi_analytics_callback callback);
  }
  #endif
  
@@ -72,10 +41,10 @@ index a5b1acf..704d5bd 100644
 \ No newline at end of file
 +#endif
 diff --git a/wifi_hal_generic.h b/wifi_hal_generic.h
-index 7edc2c4..db9ff83 100644
+index a55ede6..c8ca1a8 100644
 --- a/wifi_hal_generic.h
 +++ b/wifi_hal_generic.h
-@@ -822,6 +823,7 @@ typedef struct {
+@@ -832,6 +832,7 @@ typedef struct {
       BOOL radio_presence[MAX_NUM_RADIOS];         /**< Indicates if the interfaces is present (not in deep sleep)*/
       wifi_multi_link_info_t mu_info;
       UINT BssMaxStaAllow;                    /**< Maximum number of stations supported for given platform. Gets populated during bring-up. */


### PR DESCRIPTION
Reason for change: Need to remove merged changes from patch and update a macro in wifi_hal_ap.h
Test Procedure: Onewifi build should pass.
Risk: None