### PR TITLE
RDKBACCL-713 : Need to enable easymesh relevant flags in onewifi

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -5,8 +5,9 @@ SRCREV_libwebconfig = "7d4697bc74017e0ec57c3ba903a70dfe56809cb4"
 
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap unified-wifi-mesh-header ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-easymesh ', '', d)}"
+EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-em-app ', '', d)}"
 
-CFLAGS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -Wno-error=maybe-uninitialized -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=incompatible-pointer-types -Wno-error=sign-compare -Wno-error -DEASY_MESH_NODE -DEM_APP ', '', d)}"
+CFLAGS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -Wno-error=maybe-uninitialized -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=incompatible-pointer-types -Wno-error=sign-compare -Wno-error -DEASY_MESH_NODE ', '', d)}"
 
 do_install_append() {
       install -m 644 ${S}/include/webconfig_external_proto_easymesh.h  ${D}/usr/include/ccsp

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -7,10 +7,14 @@ SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop
 SRCREV_OneWifi = "7d4697bc74017e0ec57c3ba903a70dfe56809cb4"
 DEPENDS_append = " mesh-agent "
 DEPENDS_remove = " opensync "
+DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap ', '', d)}"
 
 CFLAGS_append = " -DWIFI_HAL_VERSION_3 -Wno-unused-function "
 LDFLAGS_append = " -ldl"
 CFLAGS_append_aarch64 = " -Wno-error "
+
+EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-em-app ', '', d)}"
+CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -DEASY_MESH_NODE ', '', d)}"
 
 SRC_URI += " \
     file://checkwifi.sh \


### PR DESCRIPTION
Reason for change:  Added required flags enabling for onewifi to support EM based on distro
Test Procedure: Able to run onewifi and em process 
Risks: Low