### PR TITLE
RDKBACCL-715 : Update wifi dependency components to tip and build on top of MLODemo

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -1,13 +1,25 @@
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=libwebconfig"
 
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=libwebconfig"
-SRCREV_libwebconfig = "7d4697bc74017e0ec57c3ba903a70dfe56809cb4"
 
+SRCREV_libwebconfig = "e958c0f8878fa5034ea8594b6f402714cfb3374e"
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap unified-wifi-mesh-header ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-easymesh ', '', d)}"
 
-CFLAGS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -Wno-error=maybe-uninitialized -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=incompatible-pointer-types -Wno-error=sign-compare -Wno-error -DEASY_MESH_NODE -DEM_APP ', '', d)}"
 
+EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-em-app ', '', d)}"
+
+CFLAGS += " -Wno-enum-conversion "
+CFLAGS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -Wno-error=maybe-uninitialized -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=incompatible-pointer-types -Wno-error=sign-compare -Wno-error -DEASY_MESH_NODE  ', '', d)}"
+
+do_compile_append() {
+    oe_runmake -C source/platform
+}
 do_install_append() {
+      oe_runmake -C source/platform DESTDIR=${D} install
       install -m 644 ${S}/include/webconfig_external_proto_easymesh.h  ${D}/usr/include/ccsp
 }
+
+FILES_${PN} += " \
+    ${libdir}/libwifi_bus.so* \
+"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=OneWifi"
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=OneWifi"
-SRCREV_OneWifi = "7d4697bc74017e0ec57c3ba903a70dfe56809cb4"
+SRCREV_OneWifi = "e958c0f8878fa5034ea8594b6f402714cfb3374e"
 DEPENDS_append = " mesh-agent "
 DEPENDS_remove = " opensync "
 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/wifihal_2_12hostap.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/wifihal_2_12hostap.patch
@@ -1,27 +1,5 @@
 Source: RDK
 Subject: Updating the API's aruguments based on hostapd-2.12
-diff --git a/platform/banana-pi/platform.c b/platform/banana-pi/platform.c
-index 5304565..aab44ce 100644
---- a/platform/banana-pi/platform.c
-+++ b/platform/banana-pi/platform.c
-@@ -33,6 +33,17 @@
- int wifi_nvram_defaultRead(char *in,char *out);
- int _syscmd(char *cmd, char *retBuf, int retBufSize);
- 
-+int update_hostap_mlo(wifi_interface_info_t *interface)
-+{
-+    return 0;
-+}
-+
-+int wifi_drv_set_ap_mlo(struct nl_msg *msg, void *priv, struct wpa_driver_ap_params *params)
-+{
-+    return 0;
-+}
-+
-+
- int wifi_nvram_defaultRead(char *in,char *out)
- {
-     char buf[MAX_BUF_SIZE]={'\0'};
 diff --git a/src/wifi_hal_dpp.c b/src/wifi_hal_dpp.c
 index 201b4de..fef031c 100644
 --- a/src/wifi_hal_dpp.c

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "1232914fc172a2ba81997b983f68970c908eadaf"
+SRCREV_rdk-wifi-hal = "a8bdea1dce2761060f54e4dfe8e69af19f3d9b1f"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY "
 CFLAGS_append_kirkstone = " -fcommon"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-util"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-util"
-SRCREV_rdk-wifi-util = "51ce6f510012f1d3989bbe7141429498c9158d82"
+SRCREV_rdk-wifi-util = "a8bdea1dce2761060f54e4dfe8e69af19f3d9b1f"


### PR DESCRIPTION

Reason for change: Updating wifi dependency components to tip revision and build on top of MLODemo changes
Test Procedure: bitbake rdk-generic-broadband-image
Risks: None.