### PR TITLE
RDKBACCL-715 : Update wifi dependency components to tip and build on top of MLODemo

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface_tip.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface_tip.patch
@@ -1,0 +1,52 @@
+diff --git a/wifi_hal_ap.h b/wifi_hal_ap.h
+index f5c37db..d63f1b8 100644
+--- a/wifi_hal_ap.h
++++ b/wifi_hal_ap.h
+@@ -349,7 +349,8 @@
+     WIFI_RADIO_SCAN_MODE_FULL,
+     WIFI_RADIO_SCAN_MODE_ONCHAN,
+     WIFI_RADIO_SCAN_MODE_OFFCHAN,
+-    WIFI_RADIO_SCAN_MODE_SURVEY
++    WIFI_RADIO_SCAN_MODE_SURVEY,
++    WIFI_RADIO_SCAN_MODE_SELECT_CHANNELS
+ } wifi_neighborScanMode_t;
+ 
+ /**
+@@ -2775,6 +2776,7 @@
+ } __attribute__((packed)) wifi_back_haul_sta_t;
+ 
+ #define WIFI_AP_MAX_SSID_LEN    33
++#define WIFI_AP_MAX_VENDOR_IE_LEN 2310
+ typedef struct {
+     CHAR    ssid[WIFI_AP_MAX_SSID_LEN];
+     BOOL    enabled;
+@@ -2801,8 +2803,8 @@
+     mac_address_t bssid;                    /**< The BSSID. This variable should only be used in the get API. It can't used to change the interface MAC */
+     UINT   wmmNoAck;
+     UINT   wepKeyLength;
+-    UINT   vendor_elements_len;
+-    UCHAR *vendor_elements;
++    UCHAR vendor_elements[WIFI_AP_MAX_VENDOR_IE_LEN]; /**< The vendor elements to be added to beacon/probe response frames. Includes IE ID (0xDD), Length, and Payload */
++    USHORT vendor_elements_len;        /**< Length of vendor_elements currently stored since it is not null terminated */
+     BOOL   bssHotspot;
+     UINT   wpsPushButton;
+     char   beaconRateCtl[32];
+diff --git a/wifi_hal_telemetry.h b/wifi_hal_telemetry.h
+index 6867002..3596ea0 100644
+--- a/wifi_hal_telemetry.h
++++ b/wifi_hal_telemetry.h
+@@ -102,6 +102,7 @@ typedef struct _wifi_neighbor_ap2
+      CHAR  ap_SupportedDataTransferRates[256];  /**< Comma-separated list (maximum list length 256) of strings. Data transmit rates (in Mbps) for unicast frames at which the SSID will permit a station to connect. For example, ifSupportedDataTransferRatesis "1,2,5.5", this indicates that the SSID will only permit connections at 1 Mbps, 2 Mbps and 5.5 Mbps. */
+      UINT  ap_DTIMPeriod;   /**< The number of beacon intervals that elapse between transmission of Beacon frames containing a TIM element whose DTIM count field is 0. This value is transmitted in the DTIM Period field of beacon frames. [802.11-2012] */
+      UINT  ap_ChannelUtilization;   /**< Indicates the fraction of the time AP senses that the channel is in use by the neighboring AP for transmissions. */
++     UINT  ap_freq;    /**< Frequency. */
+ } wifi_neighbor_ap2_t;    //COSA_DML_NEIGHTBOURING_WIFI_RESULT
+ 
+ /*    Explanation:
+@@ -338,4 +339,4 @@ INT wifi_getVAPTelemetry(UINT apIndex, wifi_VAPTelemetry_t *telemetry);
+ }
+ #endif
+ 
+-#endif
+\ No newline at end of file
++#endif

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/halinterface.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/halinterface.bbappend
@@ -2,12 +2,14 @@ CFLAGS_append = " -DWIFI_HAL_VERSION_3"
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://hal_interface.patch;apply=no "
+SRC_URI += "file://hal_interface_tip.patch;apply=no "
 #need to remove this patch once this changes merged in rdk-next
 do_hal_interface_patches() {
     cd ${S}
     if [ ! -e patch_applied ]; then
         bbnote "Patching hal_interface.patch"
         patch -p1 < ${WORKDIR}/hal_interface.patch
+        patch -p1 < ${WORKDIR}/hal_interface_tip.patch
 
        touch patch_applied
     fi


### PR DESCRIPTION

Reason for change: Fixing build issues for rdk-wifi-hal after the tip updation for wifi components
Test Procedure: bitbake rdk-generic-broadband-image
Risks: None.