### PR TITLE
RDKBACCL-716 : onewifi is not up and running if extra_oemake=--enable…

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=libwebconfig"
 
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=libwebconfig"
-SRCREV_libwebconfig = "fa41ece5df6e6589f70fcb5b554c1a835c8d0409"
+SRCREV_libwebconfig = "3962d0b1f141bc1f00ef81ff25c2a36bcd5cf4e2"
 
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap unified-wifi-mesh-header ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-easymesh ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=OneWifi"
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=OneWifi"
-SRCREV_OneWifi = "fa41ece5df6e6589f70fcb5b554c1a835c8d0409"
+SRCREV_OneWifi = "3962d0b1f141bc1f00ef81ff25c2a36bcd5cf4e2"
 DEPENDS_append = " mesh-agent "
 DEPENDS_remove = " opensync "
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap ', '', d)}"


### PR DESCRIPTION
…-em-app enabled

Reason for change: This varaiable "EM_APP_FLAG" needs to be added in cflag if we enabled EM_APP_SUPPORT in libwebconfig Makefiles. Test Procedure: No core is forming
Risks: Low