### PR TITLE
rdk-wifi-libhostap: Disable CONFIG_TESTING_OPTIONS

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/disable_config_testing_options.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/disable_config_testing_options.patch
@@ -1,0 +1,28 @@
+--- git.orig/source/hostap-2.11/src/ap/drv_callbacks.c	2025-04-25 21:17:19.391617033 +0000
++++ git/source/hostap-2.11/src/ap/drv_callbacks.c	2025-04-25 21:15:32.992889866 +0000
+@@ -1496,11 +1496,13 @@
+ 			return;
+ 	}
+ 
++#ifdef CONFIG_TESTING_OPTIONS
+ 	for_each_mld_link(p_hapd, hapd) {
+ 		if (mld->new_attlm.disabled_links & BIT(p_hapd->mld_link_id))
+ 			p_hapd->conf->mld_indicate_disabled =
+ 							mld_indicate_disabled;
+ 	}
++#endif
+ 
+ 	ieee802_11_set_beacon(hapd);
+ }
+@@ -3167,9 +3169,11 @@
+ 			   hapd->conf->iface);
+ 		hostapd_event_color_change(hapd, true);
+ 		break;
++#ifdef CONFIG_TESTING_OPTIONS
+ 	case EVENT_LINK_RECONFIG:
+ 		hostapd_link_remove_cb(hapd, data->reconfig_info.removed_links);
+ 		break;
++#endif
+ 	case EVENT_CRIT_UPDATE:
+ 		if (!data)
+ 			break;

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
@@ -42,11 +42,12 @@ file://2.11/increase_eapol_timeout.patch \
 file://2.11/Dynamic_NAS_IP_Update_2_11.patch \
 file://2.11/patch_issues_with2_12.patch \
 file://2.11/wpa3_compatibility_hostap_2_11.patch \
-file://2.11/wpa3_compatibility_telem_hostap_2_11.patch ',\
+file://2.11/wpa3_compatibility_telem_hostap_2_11.patch \
+file://2.11/disable_config_testing_options.patch',\
  ' ', d)}"
 
 do_configure_append() {
-${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'echo "CONFIG_TESTING_OPTIONS=y" >> ${S}/source/hostap-${HOSTAPD_PV}/hostapd/.config', '',d)}
+#${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'echo "CONFIG_TESTING_OPTIONS=y" >> ${S}/source/hostap-${HOSTAPD_PV}/hostapd/.config', '',d)}
 ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'echo "LIB_HDRS += ../src/common/nan.h" >> ${S}/source/hostap-${HOSTAPD_PV}/hostapd/libhostap.mk', '',d)}
 ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'echo "LIB_HDRS += ../src/ap/ubus.h" >> ${S}/source/hostap-${HOSTAPD_PV}/hostapd/libhostap.mk', '',d)}
 ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'echo "LIB_HDRS += ../src/ap/ucode.h" >> ${S}/source/hostap-${HOSTAPD_PV}/hostapd/libhostap.mk', '',d)}


### PR DESCRIPTION
Disable CONFIG_TESTING_OPTIONS in rdk-wifi-hal-libhostap package.

That option seems to be causing problems with WPA3 H2E authentication.