### PR TITLE
include below fixes

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=MLOdemo;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "a8bdea1dce2761060f54e4dfe8e69af19f3d9b1f"
+SRCREV_rdk-wifi-hal = "b0bd7dd16dc76fe8b08ed3fdec69ff19addd5970"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY -DCONFIG_HW_CAPABILITIES "
 CFLAGS_append_kirkstone = " -fcommon"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-util"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=MLOdemo;name=rdk-wifi-util"
-SRCREV_rdk-wifi-util = "a8bdea1dce2761060f54e4dfe8e69af19f3d9b1f"
+SRCREV_rdk-wifi-util = "b0bd7dd16dc76fe8b08ed3fdec69ff19addd5970"


### PR DESCRIPTION
1. move patches to source RDKBACCL-668 : Jumping Hostapd 2.11 to 2.12 for wifi 7 MLO (#162) 
  meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/nl_recv_core_2_12.patch 
  meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/wifi_core_wrt_Host2_12.patch 
  meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/wifihal_2_12hostap.patch
2. mlo: set common ssid for all vaps (#171)