### PR TITLE
RDKBACCL-317 : Port triggering support in BPI R4

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -40,7 +40,7 @@ sed -i "s/\$\$lan_ethernet_physical_ifnames=lan0 lan1 lan2 lan3 lan4/\$\$lan_eth
 sed -i "s/\$\$cmdiag_ifname=lan0$/\$\$cmdiag_ifname=net0/g" ${D}${sysconfdir}/utopia/system_defaults
 
 #Port Triggering feature has to be disabled by default
-sed -i 's/^\(\$CosaNAT::port_trigger_enabled=\)1/\10/' ${D}${sysconfdir}/utopia/system_defaults
+sed -i 's/^$CosaNAT::port_trigger_enabled=1/$CosaNAT::port_trigger_enabled=0/' ${D}${sysconfdir}/utopia/system_defaults
 
 #Script for enabling bridge mode in BPIR4.
 install -m 755 ${WORKDIR}/service_bridge_bpi.sh ${D}${sysconfdir}/utopia/service.d/

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -39,6 +39,9 @@ sed -i "s/\$\$lan_ethernet_physical_ifnames=lan0 lan1 lan2 lan3 lan4/\$\$lan_eth
 #Bridge-mode virtual interface net0 instead of lan0
 sed -i "s/\$\$cmdiag_ifname=lan0$/\$\$cmdiag_ifname=net0/g" ${D}${sysconfdir}/utopia/system_defaults
 
+#Port Triggering feature has to be disabled by default
+sed -i 's/^\(\$CosaNAT::port_trigger_enabled=\)1/\10/' ${D}${sysconfdir}/utopia/system_defaults
+
 #Script for enabling bridge mode in BPIR4.
 install -m 755 ${WORKDIR}/service_bridge_bpi.sh ${D}${sysconfdir}/utopia/service.d/
 install -m 755 ${WORKDIR}/service_bridge_bpi.sh ${D}${sysconfdir}/utopia/service.d/service_bridge.sh


### PR DESCRIPTION
Reason for change : By default, Port triggering feature in BPI has to be disabled. User can enable and test whenever required.
Test Procedure : In WebUI initially, Port triggering feature should be in disable state.
Risks : Low