### PR TITLE
RDKBACCL-746 : Onewifi core is forming whenever setting the ApplyAccessPointSettings value

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -15,6 +15,7 @@ CFLAGS_append_aarch64 = " -Wno-error "
 
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-em-app ', '', d)}"
 CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -DEASY_MESH_NODE ', '', d)}"
+CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -DEM_APP ', '', d)}"
 
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'sta_manager', 'ONEWIFI_STA_MGR_APP_SUPPORT=true', 'ONEWIFI_STA_MGR_APP_SUPPORT=false', d)}"
 CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'sta_manager', '-DONEWIFI_STA_MGR_APP_SUPPORT', '', d)}"


### PR DESCRIPTION
Reason for change: DEM_APP enabling this flag to resolve the core issue due to misalignment in easymesh enabled builds 
Test Procedure: dmcli eRT setv Device.WiFi.SSID.1.SSID string 2g
                          dmcli eRT setv Device.WiFi.ApplyAccessPointSettings bool true
                          iw dev
Risks: None.