### PR TITLE
RDKBACCL-485: Observing build errors with latest tip of onewifi

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=libwebconfig"
 
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=libwebconfig"
-SRCREV_libwebconfig = "0344e5612aba5852cca332acb9667ffe5342a85e"
+SRCREV_libwebconfig = "1eda785b86edef3701aaaa3d4b4a42a80ef98820"
 
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap unified-wifi-mesh-header ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-easymesh ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=OneWifi"
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=OneWifi"
-SRCREV_OneWifi = "0344e5612aba5852cca332acb9667ffe5342a85e"
+SRCREV_OneWifi = "1eda785b86edef3701aaaa3d4b4a42a80ef98820"
 DEPENDS_append = " mesh-agent "
 DEPENDS_remove = " opensync "
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface.patch
@@ -6,7 +6,7 @@
 #Signed-off-by:Amalesh_Nandh@comcast.com
 ################################################
 diff --git a/wifi_hal_ap.h b/wifi_hal_ap.h
-index f5c37db..7daf939 100644
+index f5c37db..9f3f732 100644
 --- a/wifi_hal_ap.h
 +++ b/wifi_hal_ap.h
 @@ -349,7 +349,8 @@ typedef enum
@@ -19,7 +19,17 @@ index f5c37db..7daf939 100644
  } wifi_neighborScanMode_t;
  
  /**
-@@ -2736,6 +2737,14 @@ typedef struct {
+@@ -2711,7 +2712,9 @@ typedef struct {
+ typedef struct {
+     BOOL mld_enable;
+     UINT mld_id;
++    UINT mld_link_id;
+     mac_address_t mld_addr;
++    BOOL mld_apply;
+ } __attribute__((packed)) wifi_mld_common_info_t;
+ 
+ typedef struct {
+@@ -2736,6 +2739,14 @@ typedef struct {
  } __attribute__((packed)) wifi_back_haul_sta_t;
  
  #define WIFI_AP_MAX_SSID_LEN    33
@@ -30,20 +40,20 @@ index f5c37db..7daf939 100644
 + * Computed by taking Max MPDU size - ~ MAX 802.11 header size - 802.11 FCS size - ~Size of required IEs
 + * 2,310 is divisible by the typical Vendor IE size (7 = IE Type[1] + IE Length[1] + OUI[3] + VIE Type[1] + VIE Subtype [1])
 + */
-+#define WIFI_AP_MAX_VENDOR_IE_LEN 2310	
++#define WIFI_AP_MAX_VENDOR_IE_LEN 2310
  typedef struct {
      CHAR    ssid[WIFI_AP_MAX_SSID_LEN];
      BOOL    enabled;
-@@ -2763,6 +2772,8 @@ typedef struct {
+@@ -2762,6 +2773,8 @@ typedef struct {
+     mac_address_t bssid;                    /**< The BSSID. This variable should only be used in the get API. It can't used to change the interface MAC */
      UINT   wmmNoAck;
      UINT   wepKeyLength;
-     BOOL   bssHotspot;
 +    UINT   vendor_elements_len;
 +    UCHAR  vendor_elements[WIFI_AP_MAX_VENDOR_IE_LEN];
+     BOOL   bssHotspot;
      UINT   wpsPushButton;
      char   beaconRateCtl[32];
-     BOOL   network_initiated_greylist;
-@@ -2919,4 +2930,4 @@ INT wifi_hal_analytics_callback_register(wifi_analytics_callback callback);
+@@ -2919,4 +2932,4 @@ INT wifi_hal_analytics_callback_register(wifi_analytics_callback callback);
  }
  #endif
  

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "c24ac486aaed208c4deb4df1a040864c0712f487"
+SRCREV_rdk-wifi-hal = "cadadaa52712ded52dd9c7a365a1de89e35c5379"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY "
 CFLAGS_append_kirkstone = " -fcommon"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-util"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-util"
-SRCREV_rdk-wifi-util = "c24ac486aaed208c4deb4df1a040864c0712f487"
+SRCREV_rdk-wifi-util = "cadadaa52712ded52dd9c7a365a1de89e35c5379"


### PR DESCRIPTION
Reason for change: Updating onewifi and rdk-wifi-hal to latest tip revision with build error fix.
Test procedure: build should compile successfully
Risks: None