### PR TITLE
RDKBACCL-755 : Create SD Flash layout for BPI R4

### DIFF
--- a/wic/sdimage-Bananapi.wks
+++ b/wic/sdimage-Bananapi.wks
@@ -3,10 +3,19 @@
 
 bootloader --ptable gpt --timeout=0
 
+# A set
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2.img" --part-name bl2 --align 17 --fixed-size 4079K --active --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip.bin" --part-name fip --align 6656 --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 8704 --fixed-size 100M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part /boot_a --source bootimg-partition --fstype=vfat --label boot_a --active --fixed-size 100M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 111104
+part /root_a --source rootfs --fstype=ext4 --label rootfs_a --fixed-size 512M
+
+# B set for Firmware Upgrade
+part /boot_b --source bootimg-partition --fstype=vfat --label boot_b --active --fixed-size 100M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+
+part /root_b --source rootfs --fstype=ext4 --label rootfs_b --fixed-size 512M
+
+# Optional data
+part /data --source=empty --fstype=ext4 --label data --fixed-size 256M


### PR DESCRIPTION
Reason for change : In BPI, for Firmware Upgrade support, necessary partitions has to be created for flashing the new image after reboot. So, enabled the SD card partitions in RDK-B build.
Test Procedure : On boot-up, BPI should have all the partitions required for firmware upgrade and bank switching. Tested using "ls -l /dev/mmcblk0*" and "fdisk /dev/mmcblk0 -l" command
Risks : Low