### PR TITLE
RDKBACCL-323 : Need to update latest srcrev in uwm and dependent components

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "cadadaa52712ded52dd9c7a365a1de89e35c5379"
+SRCREV_rdk-wifi-hal = "5c33f564833bf6fea255fd7a870efad5faa8aecf"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY "
 CFLAGS_append_kirkstone = " -fcommon"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-util"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-util"
-SRCREV_rdk-wifi-util = "cadadaa52712ded52dd9c7a365a1de89e35c5379"
+SRCREV_rdk-wifi-util = "5c33f564833bf6fea255fd7a870efad5faa8aecf"


### PR DESCRIPTION

Reason for change: Updated srcrev to fix backhaul connectivity issues
Test procedure: Able to compile the build
Risks: None