### PR TITLE
RDKBACCL-755 : Create SD Flash layout for BPI R4

### DIFF
--- a/wic/sdimage-Bananapi.wks
+++ b/wic/sdimage-Bananapi.wks
@@ -10,13 +10,12 @@ part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2.img" --part-name
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip.bin" --part-name fip --align 6656 --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 3. Boot A
-part /boot_a --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_a --active --align 8704 --fixed-size 100M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_a --active --align 8704 --fixed-size 100M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 4. rootfs A
-part /root_a --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_a --align 111104
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_a --align 111104
 
 # 5. MAC A (512KB)
-#part --source=rawcopy --sourceparams="file=mac/mac_a.bin" --part-name=mac_a --fixed-size=512K
 part --source=empty --label=mac_a --fixed-size=512K
 
 # 6. NVRAM A (2MB)
@@ -27,13 +26,12 @@ part --source=empty --fstype=ext4 --label=crash_a --fixed-size=8M
 
 
 # 8. Boot B
-part /boot_b --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 100M
+part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 100M
 
 # 9. rootfs B
-part /root_b --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_b --fixed-size 512M
+part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_b --fixed-size 512M
 
 # 10. MAC B (512KB)
-#part --source=rawcopy --sourceparams="file=mac/mac_b.bin" --part-name=mac_b --fixed-size=512K
 part --source=empty --label=mac_b --fixed-size=512K
 
 # 11. NVRAM B (2MB)

--- a/wic/sdimage-Bananapi.wks
+++ b/wic/sdimage-Bananapi.wks
@@ -1,12 +1,53 @@
-# short-description: Create Bananapi Pi SD card image
-# long-description: Creates a partitioned SD card image for use with Bananapi R4.
+# short-description: Custom Bananapi R4 SD card image
+# long-description: Creates a partitioned SD card image with dual-bank layout and additional RDK-B partitions.
 
 bootloader --ptable gpt --timeout=0
 
+# 1. BL2 (aligned at 17 sectors, 4079KB)
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2.img" --part-name bl2 --align 17 --fixed-size 4079K --active --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
+# 2. FIP (aligned at 6656 sectors, 2048KB)
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip.bin" --part-name fip --align 6656 --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 8704 --fixed-size 100M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+# 3. Boot A
+part /boot_a --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_a --active --align 8704 --fixed-size 100M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 111104
+# 4. rootfs A
+part /root_a --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_a --align 111104
+
+# 5. MAC A (512KB)
+#part --source=rawcopy --sourceparams="file=mac/mac_a.bin" --part-name=mac_a --fixed-size=512K
+part --source=empty --label=mac_a --fixed-size=512K
+
+# 6. NVRAM A (2MB)
+part --source=empty --fstype=ext4 --label=nvram_a --fixed-size=2M
+
+# 7. Crash Debug A (8MB)
+part --source=empty --fstype=ext4 --label=crash_a --fixed-size=8M
+
+
+# 8. Boot B
+part /boot_b --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 100M
+
+# 9. rootfs B
+part /root_b --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_b --fixed-size 512M
+
+# 10. MAC B (512KB)
+#part --source=rawcopy --sourceparams="file=mac/mac_b.bin" --part-name=mac_b --fixed-size=512K
+part --source=empty --label=mac_b --fixed-size=512K
+
+# 11. NVRAM B (2MB)
+part --source=empty --fstype=ext4 --label=nvram_b --fixed-size=2M
+
+# 12. Crash Debug B (8MB)
+part --source=empty --fstype=ext4 --label=crash_b --fixed-size=8M
+
+# 13. Reserved (16MB)
+part --source=empty --fstype=ext4 --label=reserved --fixed-size=16M
+
+# 14. Staging (64MB)
+part --source=empty --fstype=ext4 --label=staging --fixed-size=64M
+
+# 15. DAC (256MB)
+part --source=empty --fstype=ext4 --label=dac --fixed-size=256M
+


### PR DESCRIPTION
Reason for change : In BPI, for Firmware Upgrade support, necessary partitions has to be created for flashing the new image after reboot. So, enabled the SD card partitions in RDK-B build, as per Wiki page.
Test Procedure : On boot-up, BPI should have all the partitions required for firmware upgrade and bank switching. Tested using "ls -l /dev/mmcblk0*" and "fdisk /dev/mmcblk0 -l" command
Risks : Low