### PR TITLE
REFPLTB-3431: Request to address the port number change as part of XCONF server migration

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -31,7 +31,7 @@ fi
 #Defaults for Telemetry T2 Enable
 \$T2Enable=true
 \$T2Version=2.0.1
-\$T2ConfigURL=https://xconf.rdkcentral.com:19092/loguploader/getT2Settings"  >> ${D}${sysconfdir}/utopia/system_defaults
+\$T2ConfigURL=https://xconf.rdkcentral.com/loguploader/getT2Settings"  >> ${D}${sysconfdir}/utopia/system_defaults
 
 #lan0 used for WAN Connectivity
 sed -i "s/\$\$lan_ethernet_physical_ifnames=lan0 lan1 lan2 lan3 lan4/\$\$lan_ethernet_physical_ifnames=lan1 lan2 lan3 lan4/g" ${D}${sysconfdir}/utopia/system_defaults

--- a/meta-rdk-mtk-bpir4/recipes-common/rfc/rfc_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-common/rfc/rfc_git.bbappend
@@ -1,4 +1,4 @@
 do_install_append() {
         #Set the RFC_CONFIG_SERVER_URL by sed
-        sed -i -e 's/RFC_CONFIG_SERVER_URL=.*$/RFC_CONFIG_SERVER_URL=https:\/\/xconf.rdkcentral.com:19092\/featureControl\/getSettings/' ${D}${sysconfdir}/rfc.properties
+        sed -i -e 's/RFC_CONFIG_SERVER_URL=.*$/RFC_CONFIG_SERVER_URL=https:\/\/xconf.rdkcentral.com\/featureControl\/getSettings/' ${D}${sysconfdir}/rfc.properties
 }

--- a/meta-rdk-mtk-bpir4/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -18,4 +18,8 @@ do_install_append () {
    install -m 0755 ${S}/devicebpi/scripts/self_heal_connectivity_test.sh ${D}/usr/ccsp/tad
    install -m 0755 ${S}/devicebpi/scripts/resource_monitor.sh ${D}/usr/ccsp/tad
    install -m 0755 ${S}/devicebpi/scripts/task_health_monitor.sh ${D}/usr/ccsp/tad
+
+   # Changing CLOUDURL and DCM_LOG_SERVER_URL values with migrated server
+   sed -i -e 's|^CLOUDURL=.*$|CLOUDURL="https://xconf.rdkcentral.com/xconf/swu/stb?eStbMac="|' ${D}${sysconfdir}/include.properties
+   sed -i -e 's|^DCM_LOG_SERVER_URL=.*$|DCM_LOG_SERVER_URL=https://xconf.rdkcentral.com/loguploader/getSettings|' ${D}${sysconfdir}/dcm.properties
 }


### PR DESCRIPTION
Reason for change: Updated the XCONF client configuration to reflect the new server port as part of backend migration.
Test Procedure: Verify successful build and validate XCONF functionality, ensuring correct communication over the new server.
Risks: Low