### PR TITLE
RDKBACCL-718 : Configuring BE operatingStandard for 2GHz

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=libwebconfig"
 
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=libwebconfig"
-SRCREV_libwebconfig = "1eda785b86edef3701aaaa3d4b4a42a80ef98820"
+SRCREV_libwebconfig = "5f68e4e1d965d7ceaf378a4e0bd94f8d2dcbcccd"
 
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap unified-wifi-mesh-header ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-easymesh ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=OneWifi"
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=OneWifi"
-SRCREV_OneWifi = "1eda785b86edef3701aaaa3d4b4a42a80ef98820"
+SRCREV_OneWifi = "5f68e4e1d965d7ceaf378a4e0bd94f8d2dcbcccd"
 DEPENDS_append = " mesh-agent "
 DEPENDS_remove = " opensync "
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "5c33f564833bf6fea255fd7a870efad5faa8aecf"
+SRCREV_rdk-wifi-hal = "384def11912712f0184740f10607d60be0064743"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY "
 CFLAGS_append_kirkstone = " -fcommon"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-util"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-util"
-SRCREV_rdk-wifi-util = "5c33f564833bf6fea255fd7a870efad5faa8aecf"
+SRCREV_rdk-wifi-util = "384def11912712f0184740f10607d60be0064743"


### PR DESCRIPTION
Reason for change: Updated src revision to tip for onewifi and rdk-wifi-hal
Test procedure: Build should pass
Risks: None