### PR TITLE
RDKBACCL-643: Connected client devices are listing in offline devices  in WebUI

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -46,6 +46,8 @@ sed -i 's/^$CosaNAT::port_trigger_enabled=1/$CosaNAT::port_trigger_enabled=0/' $
 install -m 755 ${WORKDIR}/service_bridge_bpi.sh ${D}${sysconfdir}/utopia/service.d/
 install -m 755 ${WORKDIR}/service_bridge_bpi.sh ${D}${sysconfdir}/utopia/service.d/service_bridge.sh
 
+sed -i '/^#TOT_MSG_MAX=\$/s/^#//' ${D}${sysconfdir}/utopia/utopia_init.sh
+
 #Adding self heal defaults
 echo "#SelfHeal
 \$ConnTest_PingInterval=60


### PR DESCRIPTION
Reason for change : uncommenting the TOT_MSG_MAX to set msg_max value as 100, so that clients will show in online when it is active
Test procedure: when Device.Hosts.Host.{i}.Active becomes true, check the WEBUI
Risks : None