### PR TITLE
RDKBACCL-834: WiFi is broadcasted in Bridge mode

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/service_bridge_bpi.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/service_bridge_bpi.sh
@@ -579,9 +579,11 @@ add_to_group()
   wifi_wifi2=`iwconfig wifi2|grep IEEE\ 802.11 | wc -l`
   if [ $wifi_wifi0 == "1" ] ; then
         brctl delif "$bridge_name" wifi0
-  elif [ $wifi_wifi1 == "1" ]; then
+  fi
+  if [ $wifi_wifi1 == "1" ]; then
         brctl delif "$bridge_name" wifi1
-  elif [ $wifi_wifi2 == "1" ]; then
+  fi
+  if [ $wifi_wifi2 == "1" ]; then
         brctl delif "$bridge_name" wifi2
   fi
   


### PR DESCRIPTION
Reason for change:
    Added code to remove all wifi interfaces from brlan0 during bridge mode
Test Procedure:
    1. Flash the Image and boot up the device
    2. Switch to Bridge mode using below cmd dmcli eRT setv Device.X_CISCO_COM_DeviceControl.LanManagementEntry.1.LanMode string bridge-static
    3. Verify that wifi interfaces are removed from brlan0 bridge using below command brctl show brlan0 Risks: None