### PR TITLE
REFPLTB-3451 : Unable to enable WPS from WebUI

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -48,3 +48,6 @@ DISTRO_FEATURES_remove = " lan0_as_wan"
 #DISTRO_FEATURES_append = " EasyMesh"
 #DISTRO_FEATURES_append = " sta_manager"
 PREFERRED_VERSION_go = "1.19.%"
+
+#Enable wps support
+DISTRO_FEATURES_append = " wps_support"


### PR DESCRIPTION
Reason for change: WPS respective code is placed under the FEATURE_SUPPORT_WPS, so enabling distro to enable this cflag
Test Procedure: dmcli eRT setv Device.WiFi.AccessPoint.1.WPS.Enable bool true
Risks: Low