### PR TITLE
RDKBACCL-858 : New meta-rdk-ext import change is not building

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
@@ -4,3 +4,4 @@ RDEPENDS_packagegroup-filogic-mt76_remove_onewifi = " \
                     wifi-test-tool \
                     vts \
 "
+RDEPENDS_packagegroup-filogic-mt76_remove_broadband = " mt76-test"


### PR DESCRIPTION
Reason for change: Removing mt76-test from BPI broadband
Test Procedure: Validate the wifi test cases
Risks: None