### PR TITLE
RDKBACCL-861 : sysint-broadband recipe using deprecated protocol

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-extended/macaddress/bpi-macaddress.bb
+++ b/meta-rdk-mtk-bpir4/recipes-extended/macaddress/bpi-macaddress.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
 inherit autotools ${@bb.utils.contains("DISTRO_FEATURES", "kirkstone", "python3native", "pythonnative", d)}  systemd
 
-SRC_URI = "${CMF_GITHUB_ROOT}/broadband-utils.git;protocol=git;nobranch=1"
+SRC_URI = "${CMF_GITHUB_ROOT}/broadband-utils;protocol=https;nobranch=1"
 
 S = "${WORKDIR}/git"
 PV = "1.0.0"

--- a/meta-rdk-mtk-bpir4/recipes-extended/serialnumber/bpi-serialnumber.bb
+++ b/meta-rdk-mtk-bpir4/recipes-extended/serialnumber/bpi-serialnumber.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
 inherit autotools ${@bb.utils.contains("DISTRO_FEATURES", "kirkstone", "python3native", "pythonnative", d)}  systemd
 
-SRC_URI = "${CMF_GITHUB_ROOT}/broadband-utils.git;protocol=git;nobranch=1"
+SRC_URI = "${CMF_GITHUB_ROOT}/broadband-utils;protocol=https;nobranch=1"
 
 S = "${WORKDIR}/git"
 PV = "1.0.0"

--- a/meta-rdk-mtk-bpir4/recipes-extended/speedtest-bpi/rdk-speedtest-cli_git.bb
+++ b/meta-rdk-mtk-bpir4/recipes-extended/speedtest-bpi/rdk-speedtest-cli_git.bb
@@ -4,7 +4,7 @@ SECTION = "net"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-SRC_URI = "${CMF_GITHUB_ROOT}/rdk-speedtest-cli.git;protocol=git;nobranch=1"
+SRC_URI = "${CMF_GITHUB_ROOT}/rdk-speedtest-cli;protocol=https;nobranch=1"
 SRCREV = "f6a906305302aea3ebfd037b0a58f8ea54a9c9ae"
 PV = "1.0.0"
 CFLAGS_append += " -DRBUS_BUILD_INTEGRATED"

--- a/meta-rdk-mtk-bpir4/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -1,4 +1,4 @@
-SRC_URI_append = "${CMF_GITHUB_ROOT}/bananapi-sysint.git;protocol=git;nobranch=1;destsuffix=git/devicebpi;name=sysintdevicebpi"
+SRC_URI_append = "${CMF_GITHUB_ROOT}/bananapi-sysint;protocol=https;nobranch=1;destsuffix=git/devicebpi;name=sysintdevicebpi"
 SRCREV_sysintdevicebpi = "9c9644d7cdb8a50db53b69995d10729192991b21"
 SRCREV_FORMAT = "1.0.0"
 


### PR DESCRIPTION
Reason for change : changed protocol from git to https
Test Procedure: Build passed
Risks: Low