### PR TITLE
RDKBACCL-870: Integrating "gw-lan-refresh" utility for banana pi

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/gw_lan_refresh.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/gw_lan_refresh.patch
@@ -1,0 +1,47 @@
+Source: Prabhudas Gannavarapu <prabhudas_gannavarapu@comcast.com>
+Subject: Adding HAL changes for gw_lan_refresh application for Banana Pi R4
+
+Index: ethsw/rdkb_hal/src/ethsw/ccsp_hal_ethsw.c
+===================================================================
+--- ethsw.orig/rdkb_hal/src/ethsw/ccsp_hal_ethsw.c
++++ ethsw/rdkb_hal/src/ethsw/ccsp_hal_ethsw.c
+@@ -622,7 +626,6 @@ CcspHalEthSwSetPortAdminStatus
+         CCSP_HAL_ETHSW_ADMIN_STATUS AdminStatus
+     )
+ {
+-    CcspHalEthSwTrace(("set port %d AdminStatus to %d", PortId, AdminStatus));
+     if(AdminStatus < CCSP_HAL_ETHSW_AdminUp || AdminStatus > CCSP_HAL_ETHSW_AdminTest)
+         return  RETURN_ERR;
+     if(PortId < 1 || PortId > MAX_LAN_PORT)
+@@ -630,20 +634,9 @@ CcspHalEthSwSetPortAdminStatus
+     
+     char cmd1[32] = {0};
+     char cmd2[32] = {0};
+-    char interface[8] = {0};
+-    char path[32] = {0};
+-
+-    strcpy(path,"/sys/class/net/eth1");
+-
+-    int eth_if=is_interface_exists(path);
+-
+-    if(eth_if == 0 )
+-        return  RETURN_ERR;
+-
+-    strcpy(interface,"eth1");
+ 
+-    sprintf(cmd1,"ip link set %s up",interface);
+-    sprintf(cmd2,"ip link set %s down",interface);
++    sprintf(cmd1,"ip link set lan%d up",PortId);
++    sprintf(cmd2,"ip link set lan%d down",PortId);
+ 
+     switch (PortId)
+     {
+@@ -661,7 +654,7 @@ CcspHalEthSwSetPortAdminStatus
+                  }
+                  else
+                  {
+-                     //system(cmd2);
++                     system(cmd2);
+                      admin_status=1;
+                  }
+              }

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
@@ -1,3 +1,4 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 CFLAGS_append += " -D_PLATFORM_BANANAPI_R4_ "
 SRC_URI_append += "file://Add_interface_Changes.patch"
+SRC_URI_append += "file://gw_lan_refresh.patch"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/gw-lan-refresh/Makefile.am
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/gw-lan-refresh/Makefile.am
@@ -1,0 +1,3 @@
+bin_PROGRAMS = gw_lan_refresh
+gw_lan_refresh_SOURCES = gw_lan_refresh.c
+gw_lan_refresh_LDFLAGS = -lhal_ethsw

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/gw-lan-refresh/configure.ac
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/gw-lan-refresh/configure.ac
@@ -1,0 +1,119 @@
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2015 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+#                                              -*- Autoconf -*-
+# Process this file with autoconf to produce configure script.
+#
+
+AC_PREREQ([2.65])
+AC_INIT([gw_lan_refresh], [1.0], [BUG-REPORT-ADDRESS])
+AM_INIT_AUTOMAKE([foreign])
+LT_INIT
+
+AC_PREFIX_DEFAULT(`pwd`)
+AC_ENABLE_SHARED
+AC_DISABLE_STATIC
+
+AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIR([m4])
+
+# Checks for programs.
+AC_PROG_CXX
+AC_PROG_CC
+AC_PROG_INSTALL
+AC_PROG_LN_S
+AC_PROG_CPP
+AM_PROG_LIBTOOL(libtool)
+
+# Specify ccsp cpu arch
+
+AC_ARG_WITH([ccsp-arch],
+[AC_HELP_STRING([--with-ccsp-arch={arm,atom,pc,mips}],
+                [specify the ccsp board CPU platform])],
+[case x"$withval" in
+   xarm)
+     CCSP_ARCH=arm
+     ;;
+   xatom)
+     CCSP_ARCH=atom
+     ;;
+   xpc)
+     CCSP_ARCH=pc
+     ;;
+   xmips)
+     CCSP_ARCH=mips
+     ;;
+   *)
+     AC_MSG_ERROR([$withval is an invalid option to --with-ccsp-arch])
+     ;;
+ esac],
+[CCSP_ARCH=''])
+if test x"${CCSP_ARCH}" != x; then
+  AC_DEFINE_UNQUOTED(CCSP_ARCH, "$CCSP_ARCH",
+                     [The board CPU architecture])
+fi
+
+AM_CONDITIONAL(CCSP_ARCH_ARM, test "x$CCSP_ARCH" = xarm)
+AM_CONDITIONAL(CCSP_ARCH_ATOM, test "x$CCSP_ARCH" = xatom)
+AM_CONDITIONAL(CCSP_ARCH_PC, test "x$CCSP_ARCH" = xpc)
+AM_CONDITIONAL(CCSP_ARCH_MIPS, test "x$CCSP_ARCH" = xmips)
+
+# Specify ccsp platform (device)
+
+AC_ARG_WITH([ccsp-platform],
+[AC_HELP_STRING([--with-ccsp-platform={intel_usg,pc,bcm}],
+                [specify the ccsp platform])],
+[case x"$withval" in
+   xintel_usg)
+     CCSP_PLATFORM=intel_usg
+     ;;
+   xpc)
+     CCSP_PLATFORM=pc
+     ;;
+   xbcm)
+     CCSP_PLATFORM=bcm
+     ;;
+   *)
+     AC_MSG_ERROR([$withval is an invalid option to --with-ccsp-platform])
+     ;;
+ esac],
+[CCSP_PLATFORM=''])
+if test x"${CCSP_PLATFORM}" != x; then
+  AC_DEFINE_UNQUOTED(CCSP_PLATFORM, "$CCSP_PLATFORM",
+                     [The CCSP platform device])
+fi
+
+
+# Checks for header files.
+AC_CHECK_HEADERS([stdlib.h string.h unistd.h])
+
+# Checks for typedefs, structures, and compiler characteristics.
+AC_HEADER_STDBOOL
+AC_C_INLINE
+
+# Checks for library functions.
+AC_FUNC_MALLOC
+
+AC_SUBST(CCSP_ARCH)
+
+AC_CONFIG_FILES(
+	Makefile
+)
+
+AC_OUTPUT
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/gw-lan-refresh/gw_lan_refresh.c
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/gw-lan-refresh/gw_lan_refresh.c
@@ -1,0 +1,74 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "ccsp/ccsp_hal_ethsw.h"
+
+#define CONSOLE_LOG_FILE "/rdklogs/logs/Consolelog.txt.0"
+
+#define DBG_PRINT(fmt ...)     {\
+    FILE     *fp        = NULL;\
+    fp = fopen ( CONSOLE_LOG_FILE, "a+");\
+    if (fp)\
+    {\
+        fprintf(fp,fmt);\
+        fclose(fp);\
+    }\
+}\
+
+
+#define SLEEP_TIME 4
+
+void refresh_external_switch()
+{
+    CCSP_HAL_ETHSW_PORT port;
+    INT max_phy_eth_ports = 0;
+
+    /* Total 3 LAN ports*/
+    max_phy_eth_ports = CCSP_HAL_ETHSW_EthPort3;
+
+    for (port = CCSP_HAL_ETHSW_EthPort1; port <= max_phy_eth_ports; port++)
+    {
+        // Disable the port
+        DBG_PRINT("%s(): setting admin status down for port %d\n", __FUNCTION__, port);
+        CcspHalEthSwSetPortAdminStatus(port, CCSP_HAL_ETHSW_AdminDown);
+    }
+
+    sleep(SLEEP_TIME);
+
+    for (port = CCSP_HAL_ETHSW_EthPort1; port <= max_phy_eth_ports; port++)
+    {
+        // Enable the port
+        DBG_PRINT("%s(): setting admin status up for port %d\n", __FUNCTION__, port);
+        CcspHalEthSwSetPortAdminStatus(port, CCSP_HAL_ETHSW_AdminUp);
+    }
+}
+
+void refresh_wifi()
+{
+    /* dis-associate connected wifi clients */
+    system ("dmcli eRT setv Device.WiFi.AccessPoint.1.X_CISCO_COM_KickAssocDevices bool true");
+    system ("dmcli eRT setv Device.WiFi.AccessPoint.2.X_CISCO_COM_KickAssocDevices bool true");
+
+}
+
+int main(int argc, char **argv)
+{
+    if (argc == 2) {
+        if (strncmp (argv[1], "ethsw", strlen ("ethsw")) == 0) {
+            DBG_PRINT ("[%s] calling to update ethsw setting \n",argv[0]);
+            refresh_external_switch();
+        }else if (strncmp (argv[1], "wifi", strlen ("wifi")) == 0) {
+            DBG_PRINT ("[%s] calling to update wifi setting \n",argv[0]);
+            refresh_wifi();
+        }
+        else {
+            
+        }
+    }else {
+        DBG_PRINT("gw_lan_refresh \n");
+        refresh_external_switch();
+        refresh_wifi();
+    }
+    return 0;
+}

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/gw-lan-refresh_git.bb
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/gw-lan-refresh_git.bb
@@ -1,0 +1,12 @@
+LICENSE = "CLOSED"
+
+DEPENDS = "hal-ethsw"
+
+SRC_URI = "file://configure.ac  \
+           file://gw_lan_refresh.c  \
+           file://Makefile.am \
+          "
+
+
+S = "${WORKDIR}"
+inherit autotools pkgconfig


### PR DESCRIPTION
Reason for change:
    Integrating gw_lan_refresh utility for banana pi.
Test Procedure:
    Execute gw_lan_refresh command from the device console and verify that lan ports are refreshing are not.
Risks: None