### PR TITLE
RDKBACCL-814: Ping Test is not working from WEBUI

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-extended/iputils/iputils_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-extended/iputils/iputils_%.bbappend
@@ -1,0 +1,9 @@
+# Removing ping binary from iputils, since busybox ping is preferred
+do_install_append() {
+    rm -f ${D}${base_bindir}/ping.${BPN}
+    rm -f ${D}${base_bindir}/ping
+}
+
+# Remove iputils-ping package entirely
+PACKAGES_remove = "${PN}-ping"
+RDEPENDS_${PN}_remove = "${PN}-ping"


### PR DESCRIPTION
Reason for change: Standardized ping behavior by using busybox instead of iputils to fix WEBUI ping issue.
Test Procedure: Ping binary alone from iputils should be installed from busybox
Risks: Low