### PR TITLE
RDKBACCL-755 : Create SD Flash layout for BPI R4

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-bsp/trusted-firmware-a/bootloader_prebuild.bb
+++ b/meta-rdk-mtk-bpir4/recipes-bsp/trusted-firmware-a/bootloader_prebuild.bb
@@ -18,11 +18,15 @@ do_configure[noexec] = "1"
 RDEPENDS_${PN}-dev = ""
 
 SRC_URI_append += " file://bpi-r4_sdmmc_bl2.img \
-                    file://bpi-r4_sdmmc_fip.bin"
+                    file://bpi-r4_sdmmc_fip.bin \
+                    file://bpi-r4_sdmmc_bl2_B.img \
+                    file://bpi-r4_sdmmc_fip_B.bin"
 
 do_deploy() {
         mkdir -p ${DEPLOYDIR}/atf/
         install -m 0644 ${WORKDIR}/bpi-r4_sdmmc_bl2.img ${DEPLOYDIR}/atf/
+        install -m 0644 ${WORKDIR}/bpi-r4_sdmmc_bl2_B.img ${DEPLOYDIR}/atf/
         install -m 0644 ${WORKDIR}/bpi-r4_sdmmc_fip.bin ${DEPLOYDIR}/atf/
+        install -m 0644 ${WORKDIR}/bpi-r4_sdmmc_fip_B.bin ${DEPLOYDIR}/atf/
 }
 addtask do_deploy after do_install

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -99,12 +99,12 @@ if [ "X$BPI_IMG_TYPE" == "Xnand" ]; then
     sed -i '/sdmmc/s/^/#/' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
 else # SD card image is default
     mkdir -p ${_TOPDIR}/downloads
-    if [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_bl2.img ] && [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_fip.bin ]; then
+    if [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_bl2.img ] && [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_fip.bin ] && [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_bl2_B.img ] && [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_fip_B.bin ]; then
         echo "Both bl2 and fip binaries are present in local workspace."
     else
         echo "**********************************************************************"
         echo "> CAUTION: YOU ARE TRYING TO BUILD SD CARD IMAGE WITHOUT BL2 AND FIP BINARIES."
-        echo "> Please download the binaries from https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_bl2.img and https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_fip.bin"
+	echo "> Please download the binaries from https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_bl2.img, https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_fip.bin, https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_bl2_B.img and https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_fip_B.bin"
         echo "> If you don't have access to above resources, please follow instruction in https://wiki.rdkcentral.com/pages/viewpage.action?pageId=354648448#SDMonoliticimagebuildandflashingstepsforBPIR4.-Buildingbl2.imgandfip.binincaseofnothavingaccesstoartifactoryrepository to build bl2 and fip binaries yourselves."
         echo "> Place those binaries under ${_TOPDIR}/downloads/"
         echo "> EXITING NOW."

--- a/wic/sdimage-Bananapi.wks
+++ b/wic/sdimage-Bananapi.wks
@@ -22,7 +22,7 @@ part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2_B.img" --part-na
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip_B.bin" --part-name fip_b --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 7. Boot B
-part /boot_b --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 8. rootfs B
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_b --fixed-size 512M

--- a/wic/sdimage-Bananapi.wks
+++ b/wic/sdimage-Bananapi.wks
@@ -10,10 +10,10 @@ part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2.img" --part-name
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip.bin" --part-name fip --align 6656 --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 3. Boot A
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_a --active --align 8704 --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_a --active --align 8704 --fixed-size 16M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 4. rootfs A
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_a --align 111104 --fixed-size 512M
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_a --fixed-size 1024M
 
 # 5. BL2 B (copy of BL2)
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2_B.img" --part-name bl2_b --fixed-size 4079K --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
@@ -22,35 +22,21 @@ part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2_B.img" --part-na
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip_B.bin" --part-name fip_b --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 7. Boot B
-part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 16M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 8. rootfs B
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_b --fixed-size 512M
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_b --fixed-size 1024M
 
-# 9. MAC A (512KB)
-part --source=empty --label=mac_a --fixed-size=512K
+# 9. NVRAM (2MB)
+part --source=empty --fstype=ext4 --label=nvram --fixed-size=2M
 
-# 10. NVRAM A (2MB)
-part --source=empty --fstype=ext4 --label=nvram_a --fixed-size=2M
-
-# 11. Crash Debug A (8MB)
+# 10. Crash Debug (8MB)
 part --source=empty --fstype=ext4 --label=crash_a --fixed-size=8M
-
-# 12. MAC B (512KB)
-part --source=empty --label=mac_b --fixed-size=512K
-
-# 13. NVRAM B (2MB)
-part --source=empty --fstype=ext4 --label=nvram_b --fixed-size=2M
-
-# 14. Crash Debug B (8MB)
 part --source=empty --fstype=ext4 --label=crash_b --fixed-size=8M
 
-# 15. Reserved (16MB)
+# 11. Reserved (16MB)
 part --source=empty --fstype=ext4 --label=reserved --fixed-size=16M
 
-# 16. Staging (256MB)
-part --source=empty --fstype=ext4 --label=staging --fixed-size=256M
-
-# 17. DAC (256MB)
-part --source=empty --fstype=ext4 --label=dac --fixed-size=256M
+# 12. DAC 
+part --source=empty --fstype=ext4 --label=dac --fixed-size=32M
 

--- a/wic/sdimage-Bananapi.wks
+++ b/wic/sdimage-Bananapi.wks
@@ -1,12 +1,56 @@
-# short-description: Create Bananapi Pi SD card image
-# long-description: Creates a partitioned SD card image for use with Bananapi R4.
+# short-description: Custom Bananapi R4 SD card image
+# long-description: Creates a partitioned SD card image with dual-bank layout and additional RDK-B partitions.
 
 bootloader --ptable gpt --timeout=0
 
+# 1. BL2 (aligned at 17 sectors, 4079KB)
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2.img" --part-name bl2 --align 17 --fixed-size 4079K --active --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
+# 2. FIP (aligned at 6656 sectors, 2048KB)
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip.bin" --part-name fip --align 6656 --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 8704 --fixed-size 100M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+# 3. Boot A
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_a --active --align 8704 --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 111104
+# 4. rootfs A
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_a --align 111104 --fixed-size 512M
+
+# 5. BL2 B (copy of BL2)
+part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2_B.img" --part-name bl2_b --fixed-size 4079K --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+
+# 6. FIP B (copy of FIP)
+part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip_B.bin" --part-name fip_b --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+
+# 7. Boot B
+part /boot_b --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+
+# 8. rootfs B
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_b --fixed-size 512M
+
+# 9. MAC A (512KB)
+part --source=empty --label=mac_a --fixed-size=512K
+
+# 10. NVRAM A (2MB)
+part --source=empty --fstype=ext4 --label=nvram_a --fixed-size=2M
+
+# 11. Crash Debug A (8MB)
+part --source=empty --fstype=ext4 --label=crash_a --fixed-size=8M
+
+# 12. MAC B (512KB)
+part --source=empty --label=mac_b --fixed-size=512K
+
+# 13. NVRAM B (2MB)
+part --source=empty --fstype=ext4 --label=nvram_b --fixed-size=2M
+
+# 14. Crash Debug B (8MB)
+part --source=empty --fstype=ext4 --label=crash_b --fixed-size=8M
+
+# 15. Reserved (16MB)
+part --source=empty --fstype=ext4 --label=reserved --fixed-size=16M
+
+# 16. Staging (256MB)
+part --source=empty --fstype=ext4 --label=staging --fixed-size=256M
+
+# 17. DAC (256MB)
+part --source=empty --fstype=ext4 --label=dac --fixed-size=256M
+


### PR DESCRIPTION
Reason for change : In BPI, for Firmware Upgrade support, necessary partitions has to be created for flashing the new image after reboot. So, enabled the SD card partitions in RDK-B build, as per Wiki page.
Test Procedure : On boot-up, BPI should have all the partitions required for firmware upgrade and bank switching. Tested using "ls -l /dev/mmcblk0*" and "fdisk /dev/mmcblk0 -l" command
Risks : Low