### PR TITLE
RDKBACCL-839,RDKBACCL-880 : Removed onewifi db & addressed build issues

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=libwebconfig"
 
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=libwebconfig"
-SRCREV_libwebconfig = "5f68e4e1d965d7ceaf378a4e0bd94f8d2dcbcccd"
+SRCREV_libwebconfig = "c958e9def3d732bdd4b7d138f444f8a438d6c1c8"
 
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap unified-wifi-mesh-header ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-easymesh ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=OneWifi"
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=OneWifi"
-SRCREV_OneWifi = "5f68e4e1d965d7ceaf378a4e0bd94f8d2dcbcccd"
+SRCREV_OneWifi = "c958e9def3d732bdd4b7d138f444f8a438d6c1c8"
 DEPENDS_append = " mesh-agent "
 DEPENDS_remove = " opensync "
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap ', '', d)}"
@@ -16,8 +16,19 @@ CFLAGS_append_aarch64 = " -Wno-error "
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-em-app ', '', d)}"
 CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -DEASY_MESH_NODE ', '', d)}"
 
+EXTRA_OECONF_remove = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' ONEWIFI_CAC_APP_SUPPORT=true ', '', d)}"
+CFLAGS_remove = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -DONEWIFI_CAC_APP_SUPPORT -DONEWIFI_DB_SUPPORT  ', '', d)}"
+
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'sta_manager', 'ONEWIFI_STA_MGR_APP_SUPPORT=true', 'ONEWIFI_STA_MGR_APP_SUPPORT=false', d)}"
 CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'sta_manager', '-DONEWIFI_STA_MGR_APP_SUPPORT', '', d)}"
+
+EXTRA_OECONF_append = " ONEWIFI_CSI_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_MOTION_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_HARVESTER_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_ANALYTICS_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_LEVL_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_WHIX_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_BLASTER_APP_SUPPORT=true"
 
 SRC_URI += " \
     file://checkwifi.sh \

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start.sh
@@ -2,11 +2,9 @@
 sleep 20
 
 #To update al_mac_addr in EasyMeshCfg.json to avoid onewifi restarting during fresh boot-up
-wan_mac="$(cat /sys/class/ieee80211/phy0/macaddress)"
+wan_mac=`ifconfig brlan0 | grep HWaddr | cut -d ' ' -f9`
 old_al_mac_addr=`cat /nvram/EasymeshCfg.json | grep AL_MAC_ADDR  | cut -d '"' -f4`
-if [ "$old_al_mac_addr" == "00:00:00:00:00:00" ]; then
-  sed -i "s/$old_al_mac_addr/$wan_mac/g" /nvram/EasymeshCfg.json
-fi  
+sed -i "s/$old_al_mac_addr/$wan_mac/g" /nvram/EasymeshCfg.json
 
 iw phy phy0 interface add wifi0 type __ap
 iw phy phy0 interface add wifi1 type __ap

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface.patch
@@ -6,7 +6,7 @@
 #Signed-off-by:Amalesh_Nandh@comcast.com
 ################################################
 diff --git a/wifi_hal_ap.h b/wifi_hal_ap.h
-index f5c37db..9f3f732 100644
+index f5c37db..e01dbbd 100644
 --- a/wifi_hal_ap.h
 +++ b/wifi_hal_ap.h
 @@ -349,7 +349,8 @@ typedef enum
@@ -19,7 +19,177 @@ index f5c37db..9f3f732 100644
  } wifi_neighborScanMode_t;
  
  /**
-@@ -2711,7 +2712,9 @@ typedef struct {
+@@ -426,6 +427,27 @@ INT wifi_getWifiTrafficStats(INT apIndex, wifi_trafficStats_t *output_struct); /
+ INT wifi_getApAssociatedDevice(INT ap_index, mac_address_t *output_deviceMacAddressArray, UINT maxNumDevices, UINT *output_numDevices);
+ #endif
+ 
++typedef enum {
++    WIFI_REASON_UNSPECIFIED = 1,
++    WIFI_REASON_PREV_AUTH_NOT_VALID = 2,
++    WIFI_REASON_DEAUTH_LEAVING = 3,
++    WIFI_REASON_STA_REQ_ASSOC_WITHOUT_AUTH = 9,
++    WIFI_REASON_MICHAEL_MIC_FAILURE = 14,
++    WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT = 15,
++    WIFI_REASON_AKMP_NOT_VALID = 20,
++    WIFI_REASON_IEEE_802_1X_AUTH_FAILED = 23,
++    WIFI_REASON_INVALID_PMKID = 49
++} wifi_reason_code_t;
++
++typedef enum {
++    WIFI_STATUS_UNSPECIFIED_FAILURE = 1,
++    WIFI_STATUS_AUTH_TIMEOUT = 16,
++    WIFI_STATUS_ASSOC_REJECTED_TEMPORARILY = 30,
++    WIFI_STATUS_ROBUST_MGMT_FRAME_POLICY_VIOLATION = 31,
++    WIFI_STATUS_AKMP_NOT_VALID = 43,
++    WIFI_STATUS_INVALID_PMKID = 53
++} wifi_status_code_t;
++
+ /* wifi_factoryResetAP() function */
+ /**
+ * @brief Restore Access point paramters to default without change other AP nor Radio parameters (No need to reboot wifi)
+@@ -1743,6 +1765,49 @@ void wifi_newApAssociatedDevice_callback_register(wifi_newApAssociatedDevice_cal
+ *
+ */
+ typedef INT ( * wifi_apDisassociatedDevice_callback)(INT apIndex, char *MAC, INT event_type);
++/* wifi_device_disassociated_callback() function */
++/**
++* @brief This call back will be invoked in onewifi when new wifi client disassociates from Access Point.
++*
++* @param[in] apIndex          Access Point Index
++* @param[in] src_mac          MAC address of disassociated device
++* @param[in] dest_mac         MAC address of AccessPoint
++* @param[in] frame_type       type of management frame
++* @param[in] event_type       type of disassociation, explicit or due to client inactivity
++*
++* @return The status of the operation
++* @retval RETURN_OK if successful
++* @retval RETURN_ERR if any error is detected
++*
++* @execution Synchronous
++* @sideeffect None
++*
++* @note This function must not suspend and must not invoke any blocking system
++* calls. It should probably just send a message to a driver event handler task.
++*
++*/
++
++typedef INT ( * wifi_device_disassociated_callback)(INT apIndex, char *src_mac,char *dest_mac, INT frame_type, INT event_type);
++typedef INT ( * wifi_apStatusCode_callback)(int apIndex, char *src_mac,char *dest_mac, int frame_type ,int status);
++/* wifi_apStatusCode_callback_register() function */
++/**
++* @brief Callback registration function.
++*
++* @param[in] callback_proc  wifi_apStatusCode_callback_register callback function
++*
++* @return The status of the operation
++* @retval RETURN_OK if successful
++* @retval RETURN_ERR if any error is detected
++*
++* @execution Synchronous
++* @sideeffect None
++*
++* @note This function must not suspend and must not invoke any blocking system
++* calls. It should probably just send a message to a driver event handler task.
++*
++*/
++
++void wifi_apStatusCode_callback_register(wifi_apStatusCode_callback callback_proc);
+ /* wifi_stamode_callback() function */
+ /**
+ * @brief This call back will be invoked for all of these assoc request,reassoc request,eapol frames
+@@ -1846,6 +1911,26 @@ void wifi_radiusEapFailure_callback_register(wifi_radiusEapFailure_callback call
+ */
+ void wifi_ap_stamode_callback_register(wifi_stamode_callback callback_proc);
+ 
++/* wifi_apStatusCode_callback_register() function */
++/**
++* @brief Callback registration function.
++*
++* @param[in] callback_proc  wifi_apStatusCode_callback_register callback function
++*
++* @return The status of the operation
++* @retval RETURN_OK if successful
++* @retval RETURN_ERR if any error is detected
++*
++* @execution Synchronous
++* @sideeffect None
++*
++* @note This function must not suspend and must not invoke any blocking system
++* calls. It should probably just send a message to a driver event handler task.
++*
++*/
++
++void wifi_apStatusCode_callback_register(wifi_apStatusCode_callback callback_proc);
++
+ typedef INT ( * wifi_radiusFallback_failover_callback)(INT apIndex, INT failure_reason);
+ 
+ void wifi_radiusFallback_failover_callback_register(wifi_radiusFallback_failover_callback callback_proc);
+@@ -1902,6 +1987,33 @@ void wifi_apDisassociatedDevice_callback_register(wifi_apDisassociatedDevice_cal
+ typedef INT ( * wifi_apDeAuthEvent_callback)(int ap_index, char *mac, int reason);
+ /** @} */  //END OF GROUP WIFI_HAL_TYPES
+ 
++/**
++ * @addtogroup WIFI_HAL_TYPES
++ * @{
++ */
++/* wifi_device_deauthenticated_callback() function */
++/**
++* @brief This call back will be invoked when DeAuth Event comes from client.
++*
++* @param[in] apIndex          Access Point Index
++* @param[in] src_mac          MAC address of client device
++* @param[in] dest_mac         MAC address of AccessPoint
++* @param[in] frame_type       type of management frame
++* @param[in] reason           type of reason, explicit or due to client inactivity
++*
++* @return The status of the operation
++* @retval RETURN_OK if successful
++* @retval RETURN_ERR if any error is detected
++*
++* @execution Synchronous
++* @sideeffect None
++*
++* @note This function must not suspend and must not invoke any blocking system
++* calls. It should probably just send a message to a driver event handler task.
++*
++*/
++
++typedef INT ( * wifi_device_deauthenticated_callback)(int ap_index, char *src_mac,char *dest_mac, int frame_type, int reason);
+ /**
+  * @addtogroup WIFI_HAL_APIS
+  * @{
+@@ -2015,6 +2127,7 @@ typedef enum
+     WIFI_MGMT_FRAME_TYPE_REASSOC_RSP=7,
+     WIFI_MGMT_FRAME_TYPE_DISASSOC=8,
+     WIFI_MGMT_FRAME_TYPE_ACTION=9,
++    WIFI_MGMT_FRAME_TYPE_AUTH_RSP = 10,
+ } wifi_mgmtFrameType_t;
+ 
+ typedef enum
+@@ -2610,6 +2723,7 @@ typedef struct {
+     UINT  eap_req_timeout;
+     UINT  eap_req_retries;
+     BOOL  disable_pmksa_caching;
++    wifi_radius_settings_t repurposed_radius;
+     char  key_id[32];  // Openflow Tag associated with a PSK.
+     union {
+         wifi_radius_settings_t  radius;
+@@ -2697,6 +2811,14 @@ typedef struct {
+     wifi_vap_name_t vap_name;
+ } __attribute__((packed)) wifi_postassoc_control_t;
+ 
++typedef struct {
++    int speed_tier; //Network Speed Tier
++} __attribute__((packed)) network_param_config_t;
++
++typedef struct {
++    network_param_config_t npc;
++} __attribute__((packed)) amenities_network_config_t;
++
+ typedef enum {
+     wifi_vap_mode_ap,
+     wifi_vap_mode_sta,
+@@ -2711,7 +2833,9 @@ typedef struct {
  typedef struct {
      BOOL mld_enable;
      UINT mld_id;
@@ -29,7 +199,7 @@ index f5c37db..9f3f732 100644
  } __attribute__((packed)) wifi_mld_common_info_t;
  
  typedef struct {
-@@ -2736,6 +2739,14 @@ typedef struct {
+@@ -2736,6 +2860,14 @@ typedef struct {
  } __attribute__((packed)) wifi_back_haul_sta_t;
  
  #define WIFI_AP_MAX_SSID_LEN    33
@@ -44,16 +214,38 @@ index f5c37db..9f3f732 100644
  typedef struct {
      CHAR    ssid[WIFI_AP_MAX_SSID_LEN];
      BOOL    enabled;
-@@ -2762,6 +2773,8 @@ typedef struct {
-     mac_address_t bssid;                    /**< The BSSID. This variable should only be used in the get API. It can't used to change the interface MAC */
-     UINT   wmmNoAck;
-     UINT   wepKeyLength;
-+    UINT   vendor_elements_len;
+@@ -2752,6 +2884,7 @@ typedef struct {
+     wifi_interworking_t interworking;
+     wifi_preassoc_control_t preassoc;
+     wifi_postassoc_control_t postassoc;
++    amenities_network_config_t am_config;
+     BOOL    mac_filter_enable;
+     wifi_mac_filter_mode_t mac_filter_mode;
+     BOOL    sec_changed;                //should not be implemented in the hal
+@@ -2768,9 +2901,14 @@ typedef struct {
+     BOOL   network_initiated_greylist;
+     BOOL   mcast2ucast;                    /**< True if 'multicast to unicast' feature is enabled for this VAP, false otherwise */
+     BOOL   connected_building_enabled;
++    BOOL   mdu_enabled;
+     wifi_mld_info_ap_t mld_info;
+     BOOL   hostap_mgt_frame_ctrl;
+     BOOL   mbo_enabled;
++    BOOL   interop_ctrl;
++    UINT   inum_sta;
 +    UCHAR  vendor_elements[WIFI_AP_MAX_VENDOR_IE_LEN];
-     BOOL   bssHotspot;
-     UINT   wpsPushButton;
-     char   beaconRateCtl[32];
-@@ -2919,4 +2932,4 @@ INT wifi_hal_analytics_callback_register(wifi_analytics_callback callback);
++    UINT   vendor_elements_len;
+ } __attribute__((packed)) wifi_front_haul_bss_t;
+ 
+ #define WIFI_BRIDGE_NAME_LEN  32
+@@ -2782,6 +2920,7 @@ typedef struct {
+     CHAR                bridge_name[WIFI_BRIDGE_NAME_LEN];
+     wifi_vap_mode_t     vap_mode;
+     wifi_vap_name_t     repurposed_vap_name;
++    CHAR                repurposed_bridge_name[WIFI_BRIDGE_NAME_LEN];
+     union {
+         wifi_front_haul_bss_t   bss_info;
+         wifi_back_haul_sta_t    sta_info;
+@@ -2919,4 +3058,4 @@ INT wifi_hal_analytics_callback_register(wifi_analytics_callback callback);
  }
  #endif
  

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "384def11912712f0184740f10607d60be0064743"
+SRCREV_rdk-wifi-hal = "41449331f701067d22e9d877057107b7506c63e3"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY "
 CFLAGS_append_kirkstone = " -fcommon"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-util"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-util"
-SRCREV_rdk-wifi-util = "384def11912712f0184740f10607d60be0064743"
+SRCREV_rdk-wifi-util = "41449331f701067d22e9d877057107b7506c63e3"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/mdu_radius_psk_auth_2_11.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/mdu_radius_psk_auth_2_11.patch
@@ -1,0 +1,456 @@
+##########################################
+From: Srijeyarankesh_JS@comcast.com
+Date: Jun 11, 2025 12:30 PM
+Source: Comcast
+##########################################
+diff --git a/source/hostap-2.11/src/ap/ap_config.h b/source/hostap-2.11/src/ap/ap_config.h
+index 77bd481..bab9661 100644
+--- a/source/hostap-2.11/src/ap/ap_config.h
++++ b/source/hostap-2.11/src/ap/ap_config.h
+@@ -503,6 +503,7 @@ struct hostapd_bss_config {
+ 	char *manufacturer;
+ 	char *model_name;
+ 	char *model_number;
++	char *fw_version;
+ 	char *serial_number;
+ 	u8 device_type[WPS_DEV_TYPE_LEN];
+ 	char *config_methods;
+@@ -998,6 +999,8 @@ struct hostapd_bss_config {
+ #endif /* CONFIG_IEEE80211BE */
+ 
+ 	int connected_building_avp;
++	int mdu;
++	int speed_tier;
+ 	int wpa_key_mgmt_rsno;
+ 	enum mfp_options ieee80211w_rsno;
+ 	int wpa_key_mgmt_rsno_2;
+diff --git a/source/hostap-2.11/src/ap/ieee802_11_auth.c b/source/hostap-2.11/src/ap/ieee802_11_auth.c
+index 913a995..64b1c07 100644
+--- a/source/hostap-2.11/src/ap/ieee802_11_auth.c
++++ b/source/hostap-2.11/src/ap/ieee802_11_auth.c
+@@ -172,6 +172,11 @@ static int hostapd_radius_acl_query(struct hostapd_data *hapd, const u8 *addr,
+ 		goto fail;
+ 	}
+ 
++	if (hapd->conf->mdu && query->radius_psk) {
++		struct sta_info *sta = ap_get_sta(hapd, addr);
++		add_comcast_radius_attributes(hapd, msg, sta);
++	}
++
+ 	if (query->anonce &&
+ 	    !radius_msg_add_ext_vs(msg, RADIUS_ATTR_EXT_VENDOR_SPECIFIC_5,
+ 				   RADIUS_VENDOR_ID_FREERADIUS,
+@@ -492,7 +497,9 @@ hostapd_acl_recv_radius(struct radius_msg *msg, struct radius_msg *req,
+ 	struct hostapd_cached_radius_acl *cache;
+ 	struct radius_sta *info;
+ 	struct radius_hdr *hdr = radius_msg_get_hdr(msg);
++	bool success = false;
+ 
++	/* Find matching query by RADIUS identifier */
+ 	query = hapd->acl_queries;
+ 	prev = NULL;
+ 	while (query) {
+@@ -505,137 +512,71 @@ hostapd_acl_recv_radius(struct radius_msg *msg, struct radius_msg *req,
+ 		return RADIUS_RX_UNKNOWN;
+ 
+ 	wpa_printf(MSG_DEBUG,
+-		   "Found matching Access-Request for RADIUS message (id=%d)",
+-		   query->radius_id);
++		   "Found matching RADIUS PSK query (id=%d)", query->radius_id);
+ 
+-	if (radius_msg_verify(
+-		    msg, shared_secret, shared_secret_len, req,
+-		    hapd->conf->radius_require_message_authenticator)) {
++	/* Verify RADIUS message authenticator */
++	if (radius_msg_verify(msg, shared_secret, shared_secret_len, req, 0)) {
+ 		wpa_printf(MSG_INFO,
+-			   "Incoming RADIUS packet did not have correct authenticator - dropped");
+-		return RADIUS_RX_INVALID_AUTHENTICATOR;
++			   "RADIUS packet authenticator verification failed - dropped");
++		goto cleanup;
+ 	}
+ 
++	/* Only process Access-Accept and Access-Reject */
+ 	if (hdr->code != RADIUS_CODE_ACCESS_ACCEPT &&
+ 	    hdr->code != RADIUS_CODE_ACCESS_REJECT) {
+ 		wpa_printf(MSG_DEBUG,
+-			   "Unknown RADIUS message code %d to ACL query",
+-			   hdr->code);
+-		return RADIUS_RX_UNKNOWN;
++			   "Unknown RADIUS message code %d for PSK query", hdr->code);
++		goto cleanup;
+ 	}
+ 
+-	/* Insert Accept/Reject info into ACL cache */
++	/* Create cache entry for the response */
+ 	cache = os_zalloc(sizeof(*cache));
+ 	if (!cache) {
+-		wpa_printf(MSG_DEBUG, "Failed to add ACL cache entry");
+-		goto done;
++		wpa_printf(MSG_DEBUG, "Failed to allocate ACL cache entry");
++		goto cleanup;
+ 	}
++
+ 	os_get_reltime(&cache->timestamp);
+ 	os_memcpy(cache->addr, query->addr, sizeof(cache->addr));
+ 	info = &cache->info;
+-	if (hdr->code == RADIUS_CODE_ACCESS_ACCEPT) {
+-		u8 *buf;
+-		size_t len;
+-
+-		if (radius_msg_get_attr_int32(msg, RADIUS_ATTR_SESSION_TIMEOUT,
+-					      &info->session_timeout) == 0)
+-			cache->accepted = HOSTAPD_ACL_ACCEPT_TIMEOUT;
+-		else
+-			cache->accepted = HOSTAPD_ACL_ACCEPT;
+-
+-		if (radius_msg_get_attr_int32(
+-			    msg, RADIUS_ATTR_ACCT_INTERIM_INTERVAL,
+-			    &info->acct_interim_interval) == 0 &&
+-		    info->acct_interim_interval < 60) {
+-			wpa_printf(MSG_DEBUG,
+-				   "Ignored too small Acct-Interim-Interval %d for STA "
+-				   MACSTR,
+-				   info->acct_interim_interval,
+-				   MAC2STR(query->addr));
+-			info->acct_interim_interval = 0;
+-		}
+-
+-		if (hapd->conf->ssid.dynamic_vlan != DYNAMIC_VLAN_DISABLED)
+-			info->vlan_id.notempty = !!radius_msg_get_vlanid(
+-				msg, &info->vlan_id.untagged,
+-				MAX_NUM_TAGGED_VLAN, info->vlan_id.tagged);
+ 
+-		decode_tunnel_passwords(hapd, shared_secret, shared_secret_len,
+-					msg, req, cache);
+-
+-		if (radius_msg_get_attr_ptr(msg, RADIUS_ATTR_USER_NAME,
+-					    &buf, &len, NULL) == 0) {
+-			info->identity = os_zalloc(len + 1);
+-			if (info->identity)
+-				os_memcpy(info->identity, buf, len);
+-		}
+-		if (radius_msg_get_attr_ptr(
+-			    msg, RADIUS_ATTR_CHARGEABLE_USER_IDENTITY,
+-			    &buf, &len, NULL) == 0) {
+-			info->radius_cui = os_zalloc(len + 1);
+-			if (info->radius_cui)
+-				os_memcpy(info->radius_cui, buf, len);
+-		}
+-
+-		if (hapd->conf->wpa_psk_radius == PSK_RADIUS_REQUIRED &&
+-		    !info->psk)
+-			cache->accepted = HOSTAPD_ACL_REJECT;
+-
+-		if (info->vlan_id.notempty &&
+-		    !hostapd_vlan_valid(hapd->conf->vlan, &info->vlan_id)) {
+-			hostapd_logger(hapd, query->addr,
+-				       HOSTAPD_MODULE_RADIUS,
+-				       HOSTAPD_LEVEL_INFO,
+-				       "Invalid VLAN %d%s received from RADIUS server",
+-				       info->vlan_id.untagged,
+-				       info->vlan_id.tagged[0] ? "+" : "");
+-			os_memset(&info->vlan_id, 0, sizeof(info->vlan_id));
+-		}
+-		if (hapd->conf->ssid.dynamic_vlan == DYNAMIC_VLAN_REQUIRED &&
+-		    !info->vlan_id.notempty)
+-			cache->accepted = HOSTAPD_ACL_REJECT;
+-	} else
++	if (hdr->code == RADIUS_CODE_ACCESS_ACCEPT) {
++		cache->accepted = HOSTAPD_ACL_ACCEPT;
++		success = true;
++	} else {
+ 		cache->accepted = HOSTAPD_ACL_REJECT;
++		success = false;
++	}
++
+ 	cache->next = hapd->acl_cache;
+ 	hapd->acl_cache = cache;
+ 
+ 	if (query->radius_psk) {
+ 		struct sta_info *sta;
+-		bool success = cache->accepted == HOSTAPD_ACL_ACCEPT ||
+-			cache->accepted == HOSTAPD_ACL_ACCEPT_TIMEOUT;
+ 
+ 		sta = ap_get_sta(hapd, query->addr);
+ 		if (!sta || !sta->wpa_sm) {
+ 			wpa_printf(MSG_DEBUG,
+-				   "No STA/SM entry found for the RADIUS PSK response");
+-			goto done;
++				   "No STA/SM entry found for RADIUS PSK response " MACSTR,
++				   MAC2STR(query->addr));
++			goto cleanup;
+ 		}
+-#ifdef NEED_AP_MLME
+-		if (success &&
+-		    (ieee802_11_set_radius_info(hapd, sta, cache->accepted,
+-						info) < 0 ||
+-		     ap_sta_bind_vlan(hapd, sta) < 0))
+-			success = false;
+-#endif /* NEED_AP_MLME */
+-		wpa_auth_sta_radius_psk_resp(sta->wpa_sm, success);
+-	} else {
+-#ifdef CONFIG_DRIVER_RADIUS_ACL
+-		hostapd_drv_set_radius_acl_auth(hapd, query->addr,
+-						cache->accepted,
+-						info->session_timeout);
+-#else /* CONFIG_DRIVER_RADIUS_ACL */
+-#ifdef NEED_AP_MLME
+-		/* Re-send original authentication frame for 802.11 processing
+-		 */
++
+ 		wpa_printf(MSG_DEBUG,
+-			   "Re-sending authentication frame after successful RADIUS ACL query");
+-		ieee802_11_mgmt(hapd, query->auth_msg, query->auth_msg_len,
+-				NULL);
+-#endif /* NEED_AP_MLME */
+-#endif /* CONFIG_DRIVER_RADIUS_ACL */
++			   "Processing RADIUS PSK response for " MACSTR " (%s)",
++			   MAC2STR(query->addr), success ? "Accept" : "Reject");
++
++		if (success) {
++			wpa_printf(MSG_DEBUG, "RADIUS PSK validation successful - resuming EAPOL 2/4");
++			wpa_auth_sta_radius_psk_resp(sta->wpa_sm, true);
++		} else {
++			wpa_printf(MSG_DEBUG, "RADIUS PSK validation failed - failing EAPOL 2/4");
++			wpa_auth_sta_radius_psk_resp(sta->wpa_sm, false);
++		}
+ 	}
+ 
+- done:
++cleanup:
++	/* Remove query from list */
+ 	if (!prev)
+ 		hapd->acl_queries = query->next;
+ 	else
+diff --git a/source/hostap-2.11/src/ap/ieee802_1x.c b/source/hostap-2.11/src/ap/ieee802_1x.c
+index 0204963..4eed9dd 100644
+--- a/source/hostap-2.11/src/ap/ieee802_1x.c
++++ b/source/hostap-2.11/src/ap/ieee802_1x.c
+@@ -769,6 +769,62 @@ static int get_ap_vlan(char *ifname)
+ }
+ #endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
++/**
++ * add_comcast_radius_attributes - Add Comcast-specific vendor attributes to RADIUS message
++ * @hapd: hostapd BSS data structure
++ * @msg: RADIUS message to add attributes to
++ * @sta: Station data structure
++ * 
++ * This function adds various Comcast vendor-specific attributes (VSAs) to a RADIUS
++ * message including network type, CM MAC, AP VLAN, SNR, and optionally connected
++ * building information.
++ */
++void add_comcast_radius_attributes(struct hostapd_data *hapd,
++                                        struct radius_msg *msg,
++                                        struct sta_info *sta)
++{
++    u8 secure, snr;
++    u32 ap_vlan;
++    char txtaddr[TXT_MAC_ADDR_LEN] = {'\0'};
++    char managed_guest_val[128] = "amncbx";
++    secure = (hapd->conf->wpa == 0) ? 1 : 2;
++    os_snprintf(txtaddr, sizeof(txtaddr), MACSTR, MAC2STR(sta->addr));
++
++	char mdu_gw_fw_version[128];
++    char mdu_qos_avp[128];
++	memset(mdu_gw_fw_version, 0, sizeof(mdu_gw_fw_version));
++	memset(mdu_qos_avp, 0, sizeof(mdu_qos_avp));
++    
++    snr = greylist_get_client_snr(hapd, txtaddr);
++    greylist_get_cmmac();
++    ap_vlan = htonl(get_ap_vlan(hapd->conf->iface));
++    if (FAIL == ap_vlan) {
++        ap_vlan = htonl(hapd->conf->ap_vlan);
++    }
++
++    radius_msg_add_comcast(msg, RADIUS_VENDOR_ATTR_COMCAST_NETWORK_TYPE,
++                          &secure, 1);
++    radius_msg_add_comcast(msg, RADIUS_VENDOR_ATTR_COMCAST_CM_MAC,
++                          cmmac, TXT_MAC_ADDR_LEN - 1);
++    radius_msg_add_comcast(msg, RADIUS_VENDOR_ATTR_COMCAST_AP_VLAN_32,
++                          (u8 *)&ap_vlan, 4);
++    radius_msg_add_comcast(msg, RADIUS_VENDOR_ATTR_COMCAST_AP_SNR,
++                          &snr, 1);
++    if (hapd->conf->connected_building_avp || hapd->conf->mdu) {
++        radius_msg_add_comcast(msg, RADIUS_VENDOR_ATTR_COMCAST_CONNECTED_BUILDING,
++                              managed_guest_val, strlen(managed_guest_val));
++    }
++    if(hapd->conf->mdu)
++	{
++		snprintf(mdu_gw_fw_version, sizeof(mdu_gw_fw_version), "%s;%s", hapd->conf->model_number,hapd->conf->fw_version);
++		snprintf(mdu_qos_avp, sizeof(mdu_qos_avp), "qos_%d",hapd->conf->speed_tier);
++		radius_msg_add_comcast(msg, RADIUS_VENDOR_ATTR_COMCAST_FIRMWARE_VERSION,
++			mdu_gw_fw_version,strlen(mdu_gw_fw_version));
++		radius_msg_add_comcast(msg, RADIUS_VENDOR_ATTR_COMCAST_MDU_QOS_AVP,
++			mdu_qos_avp,strlen(mdu_qos_avp));
++	}
++}
++
+ void ieee802_1x_encapsulate_radius(struct hostapd_data *hapd,
+ 				   struct sta_info *sta,
+ 				   const u8 *eap, size_t len)
+@@ -936,40 +992,7 @@ void ieee802_1x_encapsulate_radius(struct hostapd_data *hapd,
+ #endif /* CONFIG_HS20 */
+ #ifdef FEATURE_SUPPORT_RADIUSGREYLIST
+ 	if (hapd->conf->rdk_greylist  || hapd->conf->connected_building_avp) {
+-		u8 secure, snr;
+-		u32 ap_vlan;
+-		char txtaddr[TXT_MAC_ADDR_LEN] = {'\0'};
+-		char managed_guest_val[128] = "cb01";
+-
+-		secure = (hapd->conf->wpa == 0) ? 1 : 2;
+-
+-		os_snprintf(txtaddr, sizeof(txtaddr), MACSTR, MAC2STR(sta->addr));
+-		snr = greylist_get_client_snr(hapd, txtaddr);
+-		greylist_get_cmmac();
+-		ap_vlan = htonl(get_ap_vlan(hapd->conf->iface));
+-
+-		if (FAIL == ap_vlan) {
+-			ap_vlan = htonl(hapd->conf->ap_vlan);
+-		}
+-
+-		radius_msg_add_comcast(
+-			msg, RADIUS_VENDOR_ATTR_COMCAST_NETWORK_TYPE,
+-			&secure, 1);
+-		radius_msg_add_comcast(
+-			msg, RADIUS_VENDOR_ATTR_COMCAST_CM_MAC,
+-			cmmac, TXT_MAC_ADDR_LEN - 1);
+-		radius_msg_add_comcast(
+-			msg, RADIUS_VENDOR_ATTR_COMCAST_AP_VLAN_32,
+-			(u8 *)&ap_vlan, 4);
+-		radius_msg_add_comcast(
+-			msg, RADIUS_VENDOR_ATTR_COMCAST_AP_SNR,
+-			&snr, 1);
+-		if(hapd->conf->connected_building_avp)
+-		{
+-			radius_msg_add_comcast(
+-			msg, RADIUS_VENDOR_ATTR_COMCAST_CONNECTED_BUILDING,
+-  			managed_guest_val,strlen(managed_guest_val));
+-  		}
++		add_comcast_radius_attributes(hapd, msg, sta);
+ 	}
+ #endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
+diff --git a/source/hostap-2.11/src/ap/ieee802_1x.h b/source/hostap-2.11/src/ap/ieee802_1x.h
+index 86cf307..d658f8c 100644
+--- a/source/hostap-2.11/src/ap/ieee802_1x.h
++++ b/source/hostap-2.11/src/ap/ieee802_1x.h
+@@ -61,6 +61,8 @@ int add_common_radius_attr(struct hostapd_data *hapd,
+ 			   struct hostapd_radius_attr *req_attr,
+ 			   struct sta_info *sta,
+ 			   struct radius_msg *msg);
++void add_comcast_radius_attributes(struct hostapd_data *hapd, struct radius_msg *msg,
++	           struct sta_info *sta);
+ int add_sqlite_radius_attr(struct hostapd_data *hapd, struct sta_info *sta,
+ 			   struct radius_msg *msg, int acct);
+ void ieee802_1x_encapsulate_radius(struct hostapd_data *hapd,
+diff --git a/source/hostap-2.11/src/ap/wpa_auth.c b/source/hostap-2.11/src/ap/wpa_auth.c
+index b5c5c4e..1e595b9 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth.c
++++ b/source/hostap-2.11/src/ap/wpa_auth.c
+@@ -3684,6 +3684,7 @@ SM_STATE(WPA_PTK, PTKCALCNEGOTIATING)
+ 	u8 *key_data_buf = NULL;
+ 	size_t key_data_buf_len = 0;
+ 	bool derive_kdk, no_kdk = false;
++	int skip_radius_psk = 0;
+ 
+ 	SM_ENTRY_MA(WPA_PTK, PTKCALCNEGOTIATING, wpa_ptk);
+ 	sm->EAPOLKeyReceived = false;
+@@ -3692,6 +3693,26 @@ SM_STATE(WPA_PTK, PTKCALCNEGOTIATING)
+ 
+ 	mic_len = wpa_mic_len(sm->wpa_key_mgmt, sm->pmk_len);
+ 
++	if (sm->radius_psk_processed) {
++		wpa_printf(MSG_DEBUG, "Resumed processing after RADIUS PSK - using local PSK");
++		skip_radius_psk = 1;
++		sm->radius_psk_processed = 0;
++	}
++
++	if (wpa_auth->conf.mdu && !skip_radius_psk && 
++	    wpa_key_mgmt_wpa_psk(sm->wpa_key_mgmt) &&
++	    wpa_auth->conf.radius_psk && wpa_auth->cb->request_radius_psk &&
++	    !sm->waiting_radius_psk) {
++		wpa_printf(MSG_DEBUG, "Trying RADIUS PSK first for MDU Vap");
++		wpa_auth->cb->request_radius_psk(wpa_auth->cb_ctx, sm->addr,
++						 sm->wpa_key_mgmt,
++						 sm->ANonce,
++						 sm->last_rx_eapol_key,
++						 sm->last_rx_eapol_key_len);
++		sm->waiting_radius_psk = 1;
++		return;
++	}
++
+ 	derive_kdk = sm->wpa_auth->conf.secure_ltf &&
+ 		ieee802_11_rsnx_capab(sm->rsnxe, WLAN_RSNX_CAPAB_SECURE_LTF);
+ 
+@@ -3787,7 +3808,7 @@ SM_STATE(WPA_PTK, PTKCALCNEGOTIATING)
+ 			   MACSTR, MAC2STR(sm->addr));
+ 	}
+ 
+-	if (!ok && wpa_key_mgmt_wpa_psk_no_sae(sm->wpa_key_mgmt) &&
++	if (!ok && !skip_radius_psk && wpa_key_mgmt_wpa_psk_no_sae(sm->wpa_key_mgmt) &&
+ 	    wpa_auth->conf.radius_psk && wpa_auth->cb->request_radius_psk &&
+ 	    !sm->waiting_radius_psk) {
+ 		wpa_printf(MSG_DEBUG, "No PSK available - ask RADIUS server");
+@@ -7234,7 +7255,8 @@ void wpa_auth_sta_radius_psk_resp(struct wpa_state_machine *sm, bool success)
+ 	} else {
+ 		sm->Disconnect = true;
+ 	}
+-
++	
++    sm->radius_psk_processed = 1;
+ 	eloop_register_timeout(0, 0, wpa_sm_call_step, sm, NULL);
+ }
+ 
+diff --git a/source/hostap-2.11/src/ap/wpa_auth.h b/source/hostap-2.11/src/ap/wpa_auth.h
+index e72a432..696e6ed 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth.h
++++ b/source/hostap-2.11/src/ap/wpa_auth.h
+@@ -284,7 +284,7 @@ struct wpa_auth_config {
+ 	 * PTK derivation regardless of advertised capabilities.
+ 	 */
+ 	bool force_kdk_derivation;
+-
++    bool mdu;
+ 	bool radius_psk;
+ 
+ 	bool no_disconnect_on_group_keyerror;
+diff --git a/source/hostap-2.11/src/ap/wpa_auth_glue.c b/source/hostap-2.11/src/ap/wpa_auth_glue.c
+index 367931f..a653c76 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth_glue.c
++++ b/source/hostap-2.11/src/ap/wpa_auth_glue.c
+@@ -226,7 +226,7 @@ static void hostapd_wpa_auth_conf(struct hostapd_bss_config *conf,
+ 	wconf->force_kdk_derivation = conf->force_kdk_derivation;
+ #endif /* CONFIG_TESTING_OPTIONS */
+ #endif /* CONFIG_PASN */
+-
++    wconf->mdu = conf->mdu;
+ 	wconf->radius_psk = conf->wpa_psk_radius == PSK_RADIUS_DURING_4WAY_HS;
+ 	wconf->no_disconnect_on_group_keyerror =
+ 		conf->bss_max_idle && conf->ap_max_inactivity &&
+diff --git a/source/hostap-2.11/src/ap/wpa_auth_i.h b/source/hostap-2.11/src/ap/wpa_auth_i.h
+index 4e5ba3e..f4f539a 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth_i.h
++++ b/source/hostap-2.11/src/ap/wpa_auth_i.h
+@@ -91,6 +91,7 @@ struct wpa_state_machine {
+ 	unsigned int update_snonce:1;
+ 	unsigned int alt_snonce_valid:1;
+ 	unsigned int waiting_radius_psk:1;
++	unsigned int radius_psk_processed:1;
+ #ifdef CONFIG_IEEE80211R_AP
+ 	unsigned int ft_completed:1;
+ 	unsigned int pmk_r1_name_valid:1;
+diff --git a/source/hostap-2.11/src/radius/radius.h b/source/hostap-2.11/src/radius/radius.h
+index c35223b..a8e9b4e 100644
+--- a/source/hostap-2.11/src/radius/radius.h
++++ b/source/hostap-2.11/src/radius/radius.h
+@@ -244,7 +244,9 @@ enum {
+ 	RADIUS_VENDOR_ATTR_COMCAST_AP_SNR = 136,
+ 	RADIUS_VENDOR_ATTR_COMCAST_REPLY_MESSAGE = 137,
+     RADIUS_VENDOR_ATTR_COMCAST_AP_VLAN_32 = 141,
++    RADIUS_VENDOR_ATTR_COMCAST_FIRMWARE_VERSION,
+     RADIUS_VENDOR_ATTR_COMCAST_CONNECTED_BUILDING = 143,
++    RADIUS_VENDOR_ATTR_COMCAST_MDU_QOS_AVP = 146,
+ };
+ #endif /* FEATURE_SUPPORT_RADIUSGREYLIST */

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/wpa3_pcm_rsno_2_hostap_2_11.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/wpa3_pcm_rsno_2_hostap_2_11.patch
@@ -1,0 +1,401 @@
+SOURCE:COMCAST
+
+diff --git a/source/hostap-2.11/src/ap/ap_config.c b/source/hostap-2.11/src/ap/ap_config.c
+index 5908f07c4..c3faa3f5c 100644
+--- a/source/hostap-2.11/src/ap/ap_config.c
++++ b/source/hostap-2.11/src/ap/ap_config.c
+@@ -495,11 +495,13 @@ int hostapd_setup_sae_pt(struct hostapd_bss_config *conf)
+ 
+ 	if ((conf->sae_pwe == SAE_PWE_HUNT_AND_PECK &&
+ 	     !hostapd_sae_pw_id_in_use(conf) &&
+-	     !wpa_key_mgmt_sae_ext_key(conf->wpa_key_mgmt) &&
++	     !(wpa_key_mgmt_sae_ext_key(conf->wpa_key_mgmt) ||
++   		   wpa_key_mgmt_sae_ext_key(conf->wpa_key_mgmt_rsno_2)) &&
+ 	     !hostapd_sae_pk_in_use(conf)) ||
+ 	    conf->sae_pwe == SAE_PWE_FORCE_HUNT_AND_PECK ||
+ 	    !(wpa_key_mgmt_sae(conf->wpa_key_mgmt) ||
+-		  wpa_key_mgmt_sae(conf->wpa_key_mgmt_rsno)))
++		  wpa_key_mgmt_sae(conf->wpa_key_mgmt_rsno) ||
++		  wpa_key_mgmt_sae(conf->wpa_key_mgmt_rsno_2)))
+ 			return 0; /* PT not needed */
+ 
+ 	sae_deinit_pt(ssid->pt);
+@@ -1243,7 +1245,7 @@ static bool hostapd_config_check_bss_6g(struct hostapd_bss_config *bss)
+ 	}
+ 
+ #ifdef CONFIG_SAE
+-	if (wpa_key_mgmt_sae(bss->wpa_key_mgmt) &&
++	if ((wpa_key_mgmt_sae(bss->wpa_key_mgmt) || wpa_key_mgmt_sae(bss->wpa_key_mgmt_rsno_2)) &&
+ 	    bss->sae_pwe == SAE_PWE_HUNT_AND_PECK) {
+ 		wpa_printf(MSG_INFO, "SAE: Enabling SAE H2E on 6 GHz");
+ 		bss->sae_pwe = SAE_PWE_BOTH;
+diff --git a/source/hostap-2.11/src/ap/ap_config.h b/source/hostap-2.11/src/ap/ap_config.h
+index 760f3e0ee..77bd48189 100644
+--- a/source/hostap-2.11/src/ap/ap_config.h
++++ b/source/hostap-2.11/src/ap/ap_config.h
+@@ -1000,6 +1000,8 @@ struct hostapd_bss_config {
+ 	int connected_building_avp;
+ 	int wpa_key_mgmt_rsno;
+ 	enum mfp_options ieee80211w_rsno;
++	int wpa_key_mgmt_rsno_2;
++	int rsn_pairwise_rsno_2;
+ };
+ 
+ /**
+diff --git a/source/hostap-2.11/src/ap/beacon.c b/source/hostap-2.11/src/ap/beacon.c
+index 7790a66bd..4f2773602 100644
+--- a/source/hostap-2.11/src/ap/beacon.c
++++ b/source/hostap-2.11/src/ap/beacon.c
+@@ -434,6 +434,22 @@ static u8 * hostapd_eid_rsno_ie(struct hostapd_data *hapd, u8 *pos, size_t len)
+ 	return pos + 2 + ie[1];
+ }
+ 
++static u8 * hostapd_eid_rsno_2_ie(struct hostapd_data *hapd, u8 *pos, size_t len)
++{
++	const u8 *ie;
++
++	ie = hostapd_vendor_wpa_ie(hapd, WPA_RSNO_II_OUI_TYPE);
++       if (!ie || 2U + ie[1] > len)
++	{
++		wpa_printf(MSG_ERROR, "%s IE not found in hostapd_vendor_wpa_ie \n", __func__);
++		return pos;
++	}
++
++	os_memcpy(pos, ie, 2 + ie[1]);
++
++	return pos + 2 + ie[1];
++}
++
+ static u8 * hostapd_eid_rsnxo_ie(struct hostapd_data *hapd, u8 *pos, size_t len)
+ {
+ 	const u8 *ie;
+@@ -1012,6 +1028,15 @@ static u8 * hostapd_probe_resp_fill_elems(struct hostapd_data *hapd,
+ 		pos = hostapd_eid_rsno_ie(hapd, pos, epos - pos);
+ 		pos = hostapd_eid_rsnxo_ie(hapd, pos, epos - pos);
+ 	}
++
++	if(hapd->conf->wpa_key_mgmt_rsno_2) {
++		pos = hostapd_eid_rsno_2_ie(hapd, pos, epos - pos);
++		if(!hapd->conf->wpa_key_mgmt_rsno)
++		{
++			pos = hostapd_eid_rsnxo_ie(hapd, pos, epos - pos);
++		}
++	}
++
+ #ifdef CONFIG_TESTING_OPTIONS
+ 	if (hapd->conf->presp_elements) {
+ 		os_memcpy(pos, wpabuf_head(hapd->conf->presp_elements),
+@@ -2529,6 +2554,13 @@ int ieee802_11_build_ap_params(struct hostapd_data *hapd,
+ 		tailpos = hostapd_eid_rsnxo_ie(hapd, tailpos, tail + tail_len - tailpos);
+ 	}
+ 
++	if(hapd->conf->wpa_key_mgmt_rsno_2) {
++		tailpos = hostapd_eid_rsno_2_ie(hapd, tailpos, tail + tail_len - tailpos);
++		if(!hapd->conf->wpa_key_mgmt_rsno) {
++			tailpos = hostapd_eid_rsnxo_ie(hapd, tailpos, tail + tail_len - tailpos);
++		}
++	}
++
+ 	tail_len = tailpos > tail ? tailpos - tail : 0;
+ 
+ 	resp = hostapd_probe_resp_offloads(hapd, &resp_len);
+diff --git a/source/hostap-2.11/src/ap/ieee802_11.c b/source/hostap-2.11/src/ap/ieee802_11.c
+index ce30c5aec..336fec13e 100644
+--- a/source/hostap-2.11/src/ap/ieee802_11.c
++++ b/source/hostap-2.11/src/ap/ieee802_11.c
+@@ -140,7 +140,9 @@ u8 * hostapd_eid_supp_rates(struct hostapd_data *hapd, u8 *eid)
+ 	h2e_required = (hapd->conf->sae_pwe == SAE_PWE_HASH_TO_ELEMENT ||
+ 			hostapd_sae_pw_id_in_use(hapd->conf) == 2) &&
+ 		hapd->conf->sae_pwe != SAE_PWE_FORCE_HUNT_AND_PECK &&
+-		wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt);
++		(wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt) ||
++		 wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt_rsno) ||
++		 wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt_rsno_2));
+ 	if (h2e_required)
+ 		num++;
+ 	if (num > 8) {
+@@ -219,7 +221,9 @@ u8 * hostapd_eid_ext_supp_rates(struct hostapd_data *hapd, u8 *eid)
+ 	h2e_required = (hapd->conf->sae_pwe == SAE_PWE_HASH_TO_ELEMENT ||
+ 			hostapd_sae_pw_id_in_use(hapd->conf) == 2) &&
+ 		hapd->conf->sae_pwe != SAE_PWE_FORCE_HUNT_AND_PECK &&
+-		wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt);
++		(wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt) ||
++		 wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt_rsno) ||
++		 wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt_rsno_2));
+ 	if (h2e_required)
+ 		num++;
+ 	if (num <= 8)
+@@ -1255,8 +1259,10 @@ static int sae_status_success(struct hostapd_data *hapd, u16 status_code)
+ 		sae_pwe = SAE_PWE_BOTH;
+ #endif /* CONFIG_SAE_PK */
+ 	if (sae_pwe == SAE_PWE_HUNT_AND_PECK &&
+-	    (hapd->conf->wpa_key_mgmt &
+-	     (WPA_KEY_MGMT_SAE_EXT_KEY | WPA_KEY_MGMT_FT_SAE_EXT_KEY)))
++	    ((hapd->conf->wpa_key_mgmt &
++	     (WPA_KEY_MGMT_SAE_EXT_KEY | WPA_KEY_MGMT_FT_SAE_EXT_KEY)) ||
++		 (hapd->conf->wpa_key_mgmt_rsno_2 &
++		 (WPA_KEY_MGMT_SAE_EXT_KEY | WPA_KEY_MGMT_FT_SAE_EXT_KEY))))
+ 		sae_pwe = SAE_PWE_BOTH;
+ 
+ 	return ((sae_pwe == SAE_PWE_HUNT_AND_PECK ||
+@@ -3001,7 +3007,8 @@ static void handle_auth(struct hostapd_data *hapd,
+ #endif /* CONFIG_IEEE80211R_AP */
+ #ifdef CONFIG_SAE
+ 		  ( ((hapd->conf->wpa && wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt)) ||
+-			(hapd->conf->wpa && wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt_rsno))) &&
++			(hapd->conf->wpa && wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt_rsno) ||
++		    (hapd->conf->wpa && wpa_key_mgmt_sae(hapd->conf->wpa_key_mgmt_rsno_2)))) &&
+ 	       auth_alg == WLAN_AUTH_SAE) ||
+ #endif /* CONFIG_SAE */
+ #ifdef CONFIG_FILS
+diff --git a/source/hostap-2.11/src/ap/wpa_auth.h b/source/hostap-2.11/src/ap/wpa_auth.h
+index 0d2b959c3..e72a432c7 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth.h
++++ b/source/hostap-2.11/src/ap/wpa_auth.h
+@@ -276,7 +276,9 @@ struct wpa_auth_config {
+ 	int spp_amsdu;
+ #endif /* CONFIG_DRIVER_BRCM */
+ 	int wpa_key_mgmt_rsno;
++	int wpa_key_mgmt_rsno_2;
+ 	enum mfp_options ieee80211w_rsno;
++	int rsn_pairwise_rsno_2;
+ 	/*
+ 	 * If set Key Derivation Key should be derived as part of PMK to
+ 	 * PTK derivation regardless of advertised capabilities.
+diff --git a/source/hostap-2.11/src/ap/wpa_auth_glue.c b/source/hostap-2.11/src/ap/wpa_auth_glue.c
+index a120ea932..282c716e8 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth_glue.c
++++ b/source/hostap-2.11/src/ap/wpa_auth_glue.c
+@@ -233,6 +233,8 @@ static void hostapd_wpa_auth_conf(struct hostapd_bss_config *conf,
+ 		conf->no_disconnect_on_group_keyerror;
+ 	wconf->wpa_key_mgmt_rsno = conf->wpa_key_mgmt_rsno;
+ 	wconf->ieee80211w_rsno = conf->ieee80211w_rsno;
++	wconf->wpa_key_mgmt_rsno_2 = conf->wpa_key_mgmt_rsno_2;
++	wconf->rsn_pairwise_rsno_2 = conf->rsn_pairwise_rsno_2;
+ }
+ 
+ 
+diff --git a/source/hostap-2.11/src/ap/wpa_auth_ie.c b/source/hostap-2.11/src/ap/wpa_auth_ie.c
+index e9ed19abd..efb0f7765 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth_ie.c
++++ b/source/hostap-2.11/src/ap/wpa_auth_ie.c
+@@ -662,8 +662,12 @@ int wpa_write_rsno_ie(struct wpa_auth_config *conf, u8 *buf, size_t len,
+ 		pos += PMKID_LEN;
+ 	}
+ 
++#if defined(RDK_ONEWIFI) && defined(CONFIG_IEEE80211BE)
++	if (conf->ieee80211w_rsno != NO_MGMT_FRAME_PROTECTION) {
++#else
+ 	if (conf->ieee80211w_rsno != NO_MGMT_FRAME_PROTECTION &&
+ 	    conf->group_mgmt_cipher != WPA_CIPHER_AES_128_CMAC) {
++#endif /* RDK_ONEWIFI && CONFIG_IEEE80211BE */
+ 		if (2 + 4 > buf + len - pos)
+ 			return -1;
+ 		if (pmkid == NULL) {
+@@ -723,6 +727,127 @@ int wpa_write_rsno_ie(struct wpa_auth_config *conf, u8 *buf, size_t len,
+ 	return pos - buf;
+ }
+ 
++int wpa_write_rsno_2_ie(struct wpa_auth_config *conf, u8 *buf, size_t len,
++		     const u8 *pmkid)
++{
++	struct rsno_ie_hdr_2 *hdr;
++	int num_suites, res;
++	u8 *pos, *count;
++	u32 suite;
++
++	hdr = (struct rsno_ie_hdr_2 *) buf;
++	hdr->elem_id = WLAN_EID_VENDOR_SPECIFIC;
++	WPA_PUT_BE32(hdr->oui, WPA_RSNO_II_OUI_TYPE);
++	WPA_PUT_LE16(hdr->version, RSN_VERSION);
++	pos = (u8 *) (hdr + 1);
++
++	suite = wpa_cipher_to_suite(WPA_PROTO_RSN, conf->wpa_group);
++	if (suite == 0) {
++		wpa_printf(MSG_DEBUG, "Invalid group cipher (%d).",
++				conf->wpa_group);
++		return -1;
++	}
++	RSN_SELECTOR_PUT(pos, suite);
++	pos += RSN_SELECTOR_LEN;
++
++	num_suites = 0;
++	count = pos;
++	pos += 2;
++
++	res = rsn_cipher_put_suites(pos, conf->rsn_pairwise_rsno_2);
++	num_suites += res;
++	pos += res * RSN_SELECTOR_LEN;
++
++	if (num_suites == 0) {
++		wpa_printf(MSG_DEBUG, "Invalid pairwise cipher (%d).",
++			   conf->rsn_pairwise_rsno_2);
++		return -1;
++	}
++	WPA_PUT_LE16(count, num_suites);
++
++	num_suites = 0;
++	count = pos;
++	pos += 2;
++
++#ifdef CONFIG_SAE
++	if (conf->wpa_key_mgmt_rsno_2 & WPA_KEY_MGMT_SAE_EXT_KEY) {
++		RSN_SELECTOR_PUT(pos, RSN_AUTH_KEY_MGMT_SAE_EXT_KEY);
++		pos += RSN_SELECTOR_LEN;
++		num_suites++;
++	}
++#endif /* CONFIG_SAE */
++
++#ifdef CONFIG_RSN_TESTING
++	if (rsn_testing) {
++		RSN_SELECTOR_PUT(pos, RSN_SELECTOR(0x12, 0x34, 0x56, 2));
++		pos += RSN_SELECTOR_LEN;
++		num_suites++;
++	}
++#endif /* CONFIG_RSN_TESTING */
++
++	if (num_suites == 0) {
++		wpa_printf(MSG_DEBUG, "Invalid key management type (%d).",
++			   conf->wpa_key_mgmt);
++		return -1;
++	}
++	WPA_PUT_LE16(count, num_suites);
++
++	/* RSN Capabilities */
++	WPA_PUT_LE16(pos, wpa_own_rsno_capab(conf));
++	pos += 2;
++
++	if (pmkid) {
++		if (2 + PMKID_LEN > buf + len - pos)
++			return -1;
++		/* PMKID Count */
++		WPA_PUT_LE16(pos, 1);
++		pos += 2;
++		os_memcpy(pos, pmkid, PMKID_LEN);
++		pos += PMKID_LEN;
++	}
++
++#if defined(RDK_ONEWIFI) && defined(CONFIG_IEEE80211BE)
++	if (conf->ieee80211w_rsno != NO_MGMT_FRAME_PROTECTION) {
++#else
++	if (conf->ieee80211w_rsno != NO_MGMT_FRAME_PROTECTION &&
++	    conf->group_mgmt_cipher != WPA_CIPHER_AES_128_CMAC) {
++#endif /* RDK_ONEWIFI && CONFIG_IEEE80211BE */
++		if (2 + 4 > buf + len - pos)
++			return -1;
++		if (pmkid == NULL) {
++			/* PMKID Count */
++			WPA_PUT_LE16(pos, 0);
++			pos += 2;
++		}
++
++		/* Management Group Cipher Suite */
++		switch (conf->group_mgmt_cipher) {
++		case WPA_CIPHER_AES_128_CMAC:
++			RSN_SELECTOR_PUT(pos, RSN_CIPHER_SUITE_AES_128_CMAC);
++			break;
++		case WPA_CIPHER_BIP_GMAC_128:
++			RSN_SELECTOR_PUT(pos, RSN_CIPHER_SUITE_BIP_GMAC_128);
++			break;
++		case WPA_CIPHER_BIP_GMAC_256:
++			RSN_SELECTOR_PUT(pos, RSN_CIPHER_SUITE_BIP_GMAC_256);
++			break;
++		case WPA_CIPHER_BIP_CMAC_256:
++			RSN_SELECTOR_PUT(pos, RSN_CIPHER_SUITE_BIP_CMAC_256);
++			break;
++		default:
++			wpa_printf(MSG_DEBUG,
++				   "Invalid group management cipher (0x%x)",
++				   conf->group_mgmt_cipher);
++			return -1;
++		}
++		pos += RSN_SELECTOR_LEN;
++	}
++
++	hdr->len = (pos - buf) - 2;
++
++	return pos - buf;
++}
++
+ int wpa_write_rsnxo_ie(struct wpa_auth_config *conf, u8 *buf, size_t len)
+ {
+ 	struct rsnxo_ie_hdr *hdr = (struct rsnxo_ie_hdr *) buf;
+@@ -734,7 +859,8 @@ int wpa_write_rsnxo_ie(struct wpa_auth_config *conf, u8 *buf, size_t len)
+ 	WPA_PUT_BE32(hdr->oui, WPA_RSNXO_OUI_TYPE);
+ 
+ 	pos = (u8 *) (hdr + 1);
+-	if (wpa_key_mgmt_sae(conf->wpa_key_mgmt_rsno) &&
++	if ((wpa_key_mgmt_sae(conf->wpa_key_mgmt_rsno) ||
++	     wpa_key_mgmt_sae(conf->wpa_key_mgmt_rsno_2)) &&
+ 	    (conf->sae_pwe == SAE_PWE_HASH_TO_ELEMENT ||
+ 	     conf->sae_pwe == SAE_PWE_BOTH || conf->sae_pk ||
+ 	     wpa_key_mgmt_sae_ext_key(conf->wpa_key_mgmt))) {
+@@ -825,6 +951,13 @@ int wpa_auth_gen_wpa_ie(struct wpa_authenticator *wpa_auth)
+ 			pos += res;
+ 		}
+ 
++		if( wpa_auth->conf.wpa_key_mgmt_rsno_2 ) {
++			res = wpa_write_rsno_2_ie(&wpa_auth->conf, pos,
++						buf + sizeof(buf) - pos, NULL);
++			if(res < 0) return res;
++			pos += res;
++		}
++
+ 		if( wpa_key_mgmt_sae(wpa_auth->conf.wpa_key_mgmt) ) {
+ 			res = wpa_write_rsnxe(&wpa_auth->conf, pos,
+ 						buf + sizeof(buf) - pos);
+@@ -833,7 +966,7 @@ int wpa_auth_gen_wpa_ie(struct wpa_authenticator *wpa_auth)
+ 			pos += res;
+ 		}
+ 
+-		if( wpa_key_mgmt_sae(wpa_auth->conf.wpa_key_mgmt_rsno) ) {
++		if( wpa_key_mgmt_sae(wpa_auth->conf.wpa_key_mgmt_rsno) || wpa_key_mgmt_sae(wpa_auth->conf.wpa_key_mgmt_rsno_2) ) {
+ 			res = wpa_write_rsnxo_ie(&wpa_auth->conf, pos,
+ 						buf + sizeof(buf) - pos);
+ 			if(res < 0) return res;
+@@ -1085,7 +1218,8 @@ wpa_validate_wpa_ie(struct wpa_authenticator *wpa_auth,
+ 		return WPA_INVALID_GROUP;
+ 	}
+ 
+-	key_mgmt = (data.key_mgmt & wpa_auth->conf.wpa_key_mgmt) | (data.key_mgmt & wpa_auth->conf.wpa_key_mgmt_rsno);
++	key_mgmt = (data.key_mgmt & wpa_auth->conf.wpa_key_mgmt) | (data.key_mgmt & wpa_auth->conf.wpa_key_mgmt_rsno) |
++	           (data.key_mgmt & wpa_auth->conf.wpa_key_mgmt_rsno_2);
+ 	if (!key_mgmt) {
+ 		wpa_printf(MSG_DEBUG, "Invalid WPA key mgmt (0x%x) from "
+ 			   MACSTR, data.key_mgmt, MAC2STR(sm->addr));
+@@ -1155,7 +1289,8 @@ wpa_validate_wpa_ie(struct wpa_authenticator *wpa_auth,
+ 		sm->wpa_key_mgmt = WPA_KEY_MGMT_PSK;
+ 
+ 	if (version == WPA_PROTO_RSN)
+-		ciphers = data.pairwise_cipher & wpa_auth->conf.rsn_pairwise;
++		ciphers = (data.pairwise_cipher & wpa_auth->conf.rsn_pairwise) |
++	              (data.pairwise_cipher & wpa_auth->conf.rsn_pairwise_rsno_2);
+ 	else
+ 		ciphers = data.pairwise_cipher & wpa_auth->conf.wpa_pairwise;
+ 	if (!ciphers) {
+diff --git a/source/hostap-2.11/src/common/wpa_common.h b/source/hostap-2.11/src/common/wpa_common.h
+index a8d83915f..f936b06e2 100644
+--- a/source/hostap-2.11/src/common/wpa_common.h
++++ b/source/hostap-2.11/src/common/wpa_common.h
+@@ -150,6 +150,7 @@ WPA_CIPHER_BIP_CMAC_256)
+ 
+ #define WPA_OUI_TYPE RSN_SELECTOR(0x00, 0x50, 0xf2, 1)
+ #define WPA_RSNO_OUI_TYPE RSN_SELECTOR(0x50, 0x6f, 0x9a, 0x29)
++#define WPA_RSNO_II_OUI_TYPE RSN_SELECTOR(0x50, 0x6f, 0x9a, 0x2A)
+ #define WPA_RSNXO_OUI_TYPE RSN_SELECTOR(0x50, 0x6f, 0x9a, 0x2B)
+ 
+ #define RSN_SELECTOR_PUT(a, val) WPA_PUT_BE32((u8 *) (a), (val))
+@@ -807,4 +808,12 @@ struct rsnxo_ie_hdr {
+ 	u8 oui_type;
+ }STRUCT_PACKED;
+ 
++struct rsno_ie_hdr_2 {
++	u8 elem_id;
++	u8 len;
++	u8 oui[3];
++	u8 oui_type;
++	u8 version[2]; /* little endian */
++}STRUCT_PACKED;
++
+ #endif /* WPA_COMMON_H */
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
@@ -9,6 +9,8 @@ SRC_URI_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_10', 'file
 SRC_URI_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'file://2.11/Bpi_rdkwifilibhostap_2_11_changes.patch', 'file://2.10/Bpi_rdkwifilibhostap_2_10_changes.patch', d)}"
 SRC_URI_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'file://2.11/supplicant.patch', '', d)}"
 SRC_URI_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'file://2.11/libhostap.mk', '', d)}"
+SRC_URI_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'file://2.11/wpa3_pcm_rsno_2_hostap_2_11.patch', '', d)}"
+SRC_URI_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'file://2.11/mdu_radius_psk_auth_2_11.patch', '', d)}"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DCONFIG_SME -DCONFIG_GAS "
 


### PR DESCRIPTION
with latest tip for EasyMesh enabled build
Reason for change: Addeded required cflags and code changes in bbapend recipes 
Test procedure: Onewifi process is up and running and db also not created at /opt/secure/wifi path
Risks: None