### PR TITLE
RDKBACCL-761 : enable required linux utils for Fwupgrade

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -9,7 +9,7 @@ IMAGE_INSTALL_append = " bpi-macaddress"
 
 IMAGE_INSTALL_append = " rdk-speedtest-cli"
 #Enable required linux utils for Fwupgrade
-IMAGE_INSTALL_append = " gptfdisk e2fsprogs-mke2fs"
+IMAGE_INSTALL_append = " gptfdisk e2fsprogs-mke2fs util-linux util-linux-losetup coreutils"
 
 ROOTFS_POSTPROCESS_COMMAND_append = "add_busybox_fixes; "
 


### PR DESCRIPTION
Reason for change : In BPI, for Firmware Upgrade support, we require certain linux utilities like util-linux, util-linux-losetup and coreutils. So, enabled in RDK-B build.
Test Procedure : The build directory should contain util-linux packages.
Risks : Low