### PR TITLE
RDKBACCL-972 : observing build errors in 2025Q2 and latest builds

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/unified-wifi-mesh/unified-wifi-mesh-header.bb
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/unified-wifi-mesh/unified-wifi-mesh-header.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e0b1ae637439c7d6f4487fb90163c79a"
 
 SRC_URI = "git://github.com/rdkcentral/unified-wifi-mesh.git;branch=main;protocol=https;name=Unified-wifi-mesh_header"
 PV = "git${SRCPV}"
-SRCREV_Unified-wifi-mesh_header = "${AUTOREV}"
+SRCREV_Unified-wifi-mesh_header = "4eca0f60752cb76a6e5ac86b10ba08e2ce6210bd"
 SRCREV_FORMAT = "Unified-wifi-mesh_header"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Reason for change: Added fixed srcrev in uwm-header recipe
Test Procedure: Able to compile uwm
Risks: Low