### PR TITLE
RDKBACCL-829 : For IEEE1905 builds,enable al sap in easymesh

### DIFF
--- a/conf/include/rdk-bpi-bbmasks.inc
+++ b/conf/include/rdk-bpi-bbmasks.inc
@@ -8,3 +8,4 @@ BBMASK_append_kirkstone .= "|meta-rdk-opensync/recipes/python3-jinja2/python3-ji
 BBMASK .= "|meta-cmf/recipes-core/images/rdk-ipstb-oss-image.bb"
 BBMASK .= "|meta-cmf/recipes-core/images/rdk-ipstb-oss-tdk-image.bb"
 BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '|meta-cmf-filogic/recipes-common/mesh-agent/mesh-agent.bbappend', '', d)}"
+BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES','EasyMesh','|openembedded-core/meta/recipes-devtools/rust/','',d)}"

--- a/conf/machine/bananapi4-rdk-broadband.conf
+++ b/conf/machine/bananapi4-rdk-broadband.conf
@@ -19,3 +19,6 @@ IMAGE_BOOT_FILES = "${@bb.utils.contains('DISTRO_FEATURES','sdmmc','mt7988a-bana
 do_image_wic[recrdeps] = "do_build"
 #SDCARD supported Pre build bootloader
 do_image_wic[depends] += " atf_bootloader_prebuild:do_deploy"
+
+#RUST support for EasyMesh
+RUST_PANIC_STRATEGY="${@bb.utils.contains('DISTRO_FEATURES','EasyMesh','abort','',d)}"


### PR DESCRIPTION
Reason for change: Added required changes to support rust
Test Procedure: Able to compile ieee1905
Risks: Low