### PR TITLE
RDKBACCL-839,RDKBACCL-880 : Removed onewifi db & addressed build issues

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=libwebconfig"
 
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=libwebconfig"
-SRCREV_libwebconfig = "5f68e4e1d965d7ceaf378a4e0bd94f8d2dcbcccd"
+SRCREV_libwebconfig = "850296b0a26daa25e5849176baaf289b6017b519"
 
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap unified-wifi-mesh-header ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-easymesh ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=OneWifi"
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=OneWifi"
-SRCREV_OneWifi = "5f68e4e1d965d7ceaf378a4e0bd94f8d2dcbcccd"
+SRCREV_OneWifi = "850296b0a26daa25e5849176baaf289b6017b519"
 DEPENDS_append = " mesh-agent "
 DEPENDS_remove = " opensync "
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap ', '', d)}"
@@ -18,6 +18,17 @@ CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -DEASY_M
 
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'sta_manager', 'ONEWIFI_STA_MGR_APP_SUPPORT=true', 'ONEWIFI_STA_MGR_APP_SUPPORT=false', d)}"
 CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'sta_manager', '-DONEWIFI_STA_MGR_APP_SUPPORT', '', d)}"
+
+EXTRA_OECONF_remove = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' ONEWIFI_CAC_APP_SUPPORT=true ', '', d)}"
+CFLAGS_remove = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -DONEWIFI_CAC_APP_SUPPORT -DONEWIFI_DB_SUPPORT  ', '', d)}"
+
+EXTRA_OECONF_append = " ONEWIFI_CSI_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_MOTION_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_HARVESTER_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_ANALYTICS_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_LEVL_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_WHIX_APP_SUPPORT=true"
+EXTRA_OECONF_append = " ONEWIFI_BLASTER_APP_SUPPORT=true"
 
 SRC_URI += " \
     file://checkwifi.sh \

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface.patch
@@ -6,7 +6,7 @@
 #Signed-off-by:Amalesh_Nandh@comcast.com
 ################################################
 diff --git a/wifi_hal_ap.h b/wifi_hal_ap.h
-index f5c37db..9f3f732 100644
+index 00134cc..34934c9 100644
 --- a/wifi_hal_ap.h
 +++ b/wifi_hal_ap.h
 @@ -349,7 +349,8 @@ typedef enum
@@ -19,7 +19,7 @@ index f5c37db..9f3f732 100644
  } wifi_neighborScanMode_t;
  
  /**
-@@ -2711,7 +2712,9 @@ typedef struct {
+@@ -2842,7 +2843,9 @@ typedef struct {
  typedef struct {
      BOOL mld_enable;
      UINT mld_id;
@@ -29,7 +29,7 @@ index f5c37db..9f3f732 100644
  } __attribute__((packed)) wifi_mld_common_info_t;
  
  typedef struct {
-@@ -2736,6 +2739,14 @@ typedef struct {
+@@ -2867,6 +2870,14 @@ typedef struct {
  } __attribute__((packed)) wifi_back_haul_sta_t;
  
  #define WIFI_AP_MAX_SSID_LEN    33
@@ -44,7 +44,7 @@ index f5c37db..9f3f732 100644
  typedef struct {
      CHAR    ssid[WIFI_AP_MAX_SSID_LEN];
      BOOL    enabled;
-@@ -2762,6 +2773,8 @@ typedef struct {
+@@ -2894,6 +2905,8 @@ typedef struct {
      mac_address_t bssid;                    /**< The BSSID. This variable should only be used in the get API. It can't used to change the interface MAC */
      UINT   wmmNoAck;
      UINT   wepKeyLength;
@@ -53,7 +53,7 @@ index f5c37db..9f3f732 100644
      BOOL   bssHotspot;
      UINT   wpsPushButton;
      char   beaconRateCtl[32];
-@@ -2919,4 +2932,4 @@ INT wifi_hal_analytics_callback_register(wifi_analytics_callback callback);
+@@ -3055,4 +3068,4 @@ INT wifi_hal_analytics_callback_register(wifi_analytics_callback callback);
  }
  #endif
  
@@ -61,9 +61,18 @@ index f5c37db..9f3f732 100644
 \ No newline at end of file
 +#endif
 diff --git a/wifi_hal_generic.h b/wifi_hal_generic.h
-index a55ede6..c8ca1a8 100644
+index a55ede6..c172320 100644
 --- a/wifi_hal_generic.h
 +++ b/wifi_hal_generic.h
+@@ -357,7 +357,7 @@ typedef struct {
+     unsigned short           caps;
+     unsigned int             beacon_int;
+     unsigned int             freq;
+-    unsigned char            ie[256];
++    unsigned char            ie[512];
+     size_t                   ie_len;
+     wifi_security_modes_t    sec_mode;
+     wifi_encryption_method_t enc_method;
 @@ -832,6 +832,7 @@ typedef struct {
       BOOL radio_presence[MAX_NUM_RADIOS];         /**< Indicates if the interfaces is present (not in deep sleep)*/
       wifi_multi_link_info_t mu_info;

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "384def11912712f0184740f10607d60be0064743"
+SRCREV_rdk-wifi-hal = "ec5afd02d0d87613509b325a04fa0a2fe50636cb"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY "
 CFLAGS_append_kirkstone = " -fcommon"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-util"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-util"
-SRCREV_rdk-wifi-util = "384def11912712f0184740f10607d60be0064743"
+SRCREV_rdk-wifi-util = "ec5afd02d0d87613509b325a04fa0a2fe50636cb"


### PR DESCRIPTION
with latest tip for EasyMesh enabled build
Reason for change: Addeded required cflags and code changes in bbapend recipes
Test procedure: Onewifi process is up and running and db also not created at /opt/secure/wifi path 
Risks: None