### PR TITLE
RDKBACCL-977 : Need to add socat package support for ieee1905

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-connectivity/socat/socat_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/socat/socat_%.bbappend
@@ -1,0 +1,19 @@
+EXTRA_OECONF_remove = " --disable-proxy \
+                --disable-tun \
+                --disable-stdio \
+                --disable-sctp \
+                --disable-socks4 \
+                --disable-socks4a \
+                --disable-udp \
+                --disable-fdnum \
+                --disable-creat \
+                --disable-gopen \
+                --disable-pipe \
+                --disable-unix \
+                --disable-abstract-unixsocket \
+                --disable-rawip \
+                --disable-genericsocket \
+                --disable-system \
+                --disable-readline \
+"
+

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -28,4 +28,4 @@ add_busybox_fixes() {
 }
 
 IMAGE_INSTALL_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ppp-enabled', '', 'pptp-linux rp-pppoe xl2tpd', d)}"
-IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh',' unified-wifi-mesh unified-wifi-mesh-cli','',d)}"
+IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh',' unified-wifi-mesh unified-wifi-mesh-cli socat','',d)}"


### PR DESCRIPTION
Reason for change: observing below error when we run the socat bin,
2025/07/02 09:04:00 socat[433851] E unknown device/address "UDP4-RECVFROM" 
2025/07/02 09:04:01 socat[434216] E unknown device/address "-"
so, enabled required extra_oeconf options to resolve the observed errors.
Also, this pkg is compiled whenever we enabled the EasyMesh distro 
Test procedure: socat command execution succeeded.
Risks: None