### PR TITLE
RDKBACCL-978 : Modifying the speedtest-client binary to RefSpeedtestClient

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-extended/speedtest-bpi/rdk-speedtest-cli_git.bb
+++ b/meta-rdk-mtk-bpir4/recipes-extended/speedtest-bpi/rdk-speedtest-cli_git.bb
@@ -25,11 +25,11 @@ CFLAGS_append = " \
 
 
 do_compile() {
-        ${CC} ${S}/source/rdk-speedtest-cli.c ${CFLAGS} ${LDFLAGS} -I ${S}/include -o speedtest-client
+        ${CC} ${S}/source/rdk-speedtest-cli.c ${CFLAGS} ${LDFLAGS} -I ${S}/include -o RefSpeedtestClient
 }
 
 
 do_install() {
         install -d ${D}${bindir}
-        install -m 0755 speedtest-client ${D}${bindir}/speedtest-client
+        install -m 0755 RefSpeedtestClient ${D}${bindir}/RefSpeedtestClient
 }


### PR DESCRIPTION
Test Procedure: Modified binary name should update in image folder(/usr/bin).
Risks: Low