### PR TITLE
RDKBACCL-864, RDKBACCL-946: On bootup, onewifi service is in activating state and lan/wifi clients are not working

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -51,3 +51,5 @@ PREFERRED_VERSION_go = "1.19.%"
 
 #Enable wps support
 DISTRO_FEATURES_append = " wps_support"
+
+DISTRO_FEATURES_append_broadband = " rdkb_xdsl_ppp_manager"


### PR DESCRIPTION
Reason for change: Onewifi timeout issue fixed
Test Procedure: After bootup onewifi service should be up and running within 2 mins, basic wifi sanity should pass.
Risks: Low