### PR TITLE
RDKBACCL-863 : brlan0 interface MAC ID is changing upon every device …

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-devtools/init-filogic/init-filogic.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-devtools/init-filogic/init-filogic.bbappend
@@ -16,6 +16,8 @@ if [ $? -eq 0 ];then \
                 ifconfig lan${i} hw ether $LAN_MAC \
         fi \
    done \
+   BRLAN_MAC=`cat /nvram/mac_addresses.txt | grep -a brlan0 | cut -d " " -f 2` \
+   ifconfig brlan0 hw ether $BRLAN_MAC \
 fi' ${D}${sbindir}/init-bridge.sh
 }
 


### PR DESCRIPTION
brlan0 interface MAC ID is changing upon every device reboot , added changes in the init filogic code  to update the brlan0 mac address from the text file generate, based upon the serial number which is unique same as for other interfaces like wifi0 etc