### PR TITLE
RDKBACCL-905, RDKBACCL-906: [TDK][AUTO][BPI] Command 'syscfg get custom_data_model_enabled' returns empty

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -82,8 +82,8 @@ echo "#SelfHeal
 \$EnableTR69Binary=true
 
 #Custom Data Model
-$custom_data_model_enabled=0
-$custom_data_model_file_name=/usr/ccsp/tr069pa/custom_mapper.xml"  >> ${D}${sysconfdir}/utopia/system_defaults
+\$custom_data_model_enabled=0
+\$custom_data_model_file_name=/usr/ccsp/tr069pa/custom_mapper.xml"  >> ${D}${sysconfdir}/utopia/system_defaults
 
 #Remote management
 sed -i 's/^\(\$mgmt_wan_httpsaccess=\)0/\11/' ${D}${sysconfdir}/utopia/system_defaults


### PR DESCRIPTION


[TDK][AUTO][BPI] Command 'syscfg get custom_data_model_file' returns empty

Reason for change: To add custom data model variables in system_defaults without getting changed during the build.
Test Procedure: Verify that values are properly updated in system_defaults file.
Risks: None