### PR TITLE
RDKBACCL-982 : Add systemd support for ieee1905 and EM processes

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=libwebconfig"
 
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=libwebconfig"
-SRCREV_libwebconfig = "850296b0a26daa25e5849176baaf289b6017b519"
+SRCREV_libwebconfig = "5924baad3842f75f50569e73c42b80e11c0454dc"
 
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap unified-wifi-mesh-header ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-easymesh ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=OneWifi"
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=OneWifi"
-SRCREV_OneWifi = "850296b0a26daa25e5849176baaf289b6017b519"
+SRCREV_OneWifi = "5924baad3842f75f50569e73c42b80e11c0454dc"
 DEPENDS_append = " mesh-agent "
 DEPENDS_remove = " opensync "
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap ', '', d)}"
@@ -32,13 +32,13 @@ EXTRA_OECONF_append = " ONEWIFI_BLASTER_APP_SUPPORT=true"
 
 SRC_URI += " \
     file://checkwifi.sh \
-    file://onewifi_pre_start.sh \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', bb.utils.contains('DISTRO_FEATURES', 'em_extender', 'file://onewifi_pre_start_em_ext.sh ','file://onewifi_pre_start_em_ctrl.sh ', d), 'file://onewifi_pre_start.sh ', d)} \
     file://wifi_defaults.txt \
 "
 do_install_append(){
     install -d ${D}/nvram 
     install -m 777 ${WORKDIR}/checkwifi.sh ${D}/usr/ccsp/wifi/
-    install -m 777 ${WORKDIR}/onewifi_pre_start.sh ${D}/usr/ccsp/wifi/
+    install -m 777 ${WORKDIR}/onewifi_pre_*.sh ${D}/usr/ccsp/wifi/onewifi_pre_start.sh
     install -m 644 ${WORKDIR}/wifi_defaults.txt ${D}/nvram/
 }
 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ctrl.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ctrl.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+sleep 20
+
+iw phy phy0 interface add wifi0 type __ap
+iw phy phy0 interface add wifi1 type __ap
+iw phy phy0 interface add wifi1.1 type __ap
+iw phy phy0 interface add wifi2 type __ap
+
+#Obtain the wifi0 mac address
+wifi0_mac="$(cat /sys/class/ieee80211/phy0/macaddress)"
+#Strip the : and increment mac by 1 to get wifi1 macaddress
+mac=$(echo $wifi0_mac | tr -d ':')
+mac_incr=$((0x$mac + 2))
+wifi1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+mac_incr=$(($mac_incr + 2))
+wifi1_1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment again by 1 to get wifi2 address
+mac_incr=$(($mac_incr + 2))
+wifi2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+mac_incr=$(($mac_incr + 2))
+wifi2_1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#print the mac address
+echo $wifi0_mac
+echo $wifi1_mac
+echo $wifi2_mac
+
+#Update the mac address using ip link command
+ifconfig wifi0 down
+ifconfig wifi1 down
+ifconfig wifi1.1 down
+ifconfig wifi2 down
+
+ip link set dev wifi0 address $wifi0_mac
+ip link set dev wifi1 address $wifi1_mac
+ip link set dev wifi1.1 address $wifi1_1_mac
+ip link set dev wifi2 address $wifi2_mac
+
+ifconfig wifi0 up
+ifconfig wifi1 up
+ifconfig wifi1.1 up
+ifconfig wifi2 up
+
+exit 0

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ext.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ext.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+sleep 5
+
+iw phy phy0 interface add wifi0 type __ap
+iw phy phy0 interface add wifi0.1 type __ap
+iw phy phy0 interface add wifi1 type __ap
+iw phy phy0 interface add wifi2 type __ap
+iw phy phy0 interface add wifi1.1 type __ap
+
+#Obtain the wifi0 mac address
+wifi_mac="$(cat /sys/class/ieee80211/phy0/macaddress)"
+#Strip the : and increment mac by 1 to get wifi1 macaddress
+mac=$(echo $wifi_mac | tr -d ':')
+mac_incr=$((0x$mac + 8))
+wifi0_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment again by 1 to get wifi2 address
+mac_incr=$(($mac_incr + 1))
+wifi0_1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment again by 1 to get wifi2 address
+mac_incr=$(($mac_incr + 1))
+wifi1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+mac_incr=$(($mac_incr + 1))
+wifi1_1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+mac_incr=$(($mac_incr + 1))
+wifi2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#print the mac address
+echo $wifi0_mac
+echo $wifi1_mac
+echo $wifi2_mac
+
+#Update the mac address using ip link command
+ifconfig wifi0 down
+ifconfig wifi0.1 down
+ifconfig wifi1 down
+ifconfig wifi1.1 down
+ifconfig wifi2 down
+ip link set dev wifi0 address $wifi0_mac
+ip link set dev wifi0.1 address $wifi0_1_mac
+ip link set dev wifi1 address $wifi1_mac
+ip link set dev wifi1.1 address $wifi1_1_mac
+ip link set dev wifi2 address $wifi2_mac
+ifconfig wifi0 up
+ifconfig wifi1 up
+ifconfig wifi1.1 up
+ifconfig wifi2 up
+
+#To update al_mac addr in EasymesgCfg.json
+al_mac_addr=`cat /nvram/EasymeshCfg.json | grep AL_MAC_ADDR  | cut -d '"' -f4`
+al_mac=`iw dev wifi1.1 info | grep addr | cut -d ' ' -f2`
+
+if [ "$al_mac_addr" = "00:00:00:00:00:00" ]; then
+        sed -i "s/$al_mac_addr/$al_mac/g" /nvram/EasymeshCfg.json
+fi
+
+exit 0

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/EasymeshCfg_ext.json
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/EasymeshCfg_ext.json
@@ -1,0 +1,7 @@
+{
+	"AL_MAC_ADDR":	"00:00:00:00:00:00",
+	"Colocated_mode":	0,
+	"Backhaul_SSID":	"mesh_backhaul",
+	"Backhaul_KeyPassphrase":	"test-backhaul",
+        "sta_4addr_mode_enabled": true 
+}

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em_ctrl.json
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em_ctrl.json
@@ -1,0 +1,56 @@
+{
+    "PhyList": [
+        {
+            "Index": 0,
+            "RadioList": [
+                 {
+                    "Index": 2,
+                    "RadioName": "wifi2",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wifi2",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 3,
+                            "vapName": "private_ssid_6g"
+                        }
+                    ]
+                },
+                {
+                    "Index": 1,
+                    "RadioName": "wifi1",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wifi1.1",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 2,
+                            "vapName": "mesh_backhaul_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi1",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 1,
+                            "vapName": "private_ssid_5g"
+                        }
+                        
+                    ]
+                },
+                {
+                    "Index": 0,
+                    "RadioName": "wifi0",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wifi0",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 0,
+                            "vapName": "private_ssid_2g"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em_ext.json
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em_ext.json
@@ -1,0 +1,63 @@
+{
+    "PhyList": [
+        {
+            "Index": 0,
+            "RadioList": [
+                 {
+                    "Index": 2,
+                    "RadioName": "wifi2",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wifi2",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 4,
+                            "vapName": "private_ssid_6g"
+                        }
+                    ]
+                },
+                {
+                    "Index": 1,
+                    "RadioName": "wifi1",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wifi1.1",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 3,
+                            "vapName": "mesh_sta_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi1",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 2,
+                            "vapName": "private_ssid_5g"
+                        }
+                        
+                    ]
+                },
+                {
+                    "Index": 0,
+                    "RadioName": "wifi0",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wifi0.1",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 1,
+                            "vapName": "mesh_backhaul_2g"
+                        },
+                        {
+                            "InterfaceName": "wifi0",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 0,
+                            "vapName": "private_ssid_2g"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/hal_interface.patch
@@ -6,7 +6,7 @@
 #Signed-off-by:Amalesh_Nandh@comcast.com
 ################################################
 diff --git a/wifi_hal_ap.h b/wifi_hal_ap.h
-index 00134cc..34934c9 100644
+index 00134cc..dca93e7 100644
 --- a/wifi_hal_ap.h
 +++ b/wifi_hal_ap.h
 @@ -349,7 +349,8 @@ typedef enum
@@ -19,7 +19,15 @@ index 00134cc..34934c9 100644
  } wifi_neighborScanMode_t;
  
  /**
-@@ -2842,7 +2843,9 @@ typedef struct {
+@@ -2112,6 +2113,7 @@ typedef enum
+     WIFI_MGMT_FRAME_TYPE_DISASSOC=8,
+     WIFI_MGMT_FRAME_TYPE_ACTION=9,
+     WIFI_MGMT_FRAME_TYPE_AUTH_RSP = 10,
++    WIFI_MGMT_FRAME_TYPE_BEACON = 11,
+ } wifi_mgmtFrameType_t;
+ 
+ typedef enum
+@@ -2842,7 +2844,9 @@ typedef struct {
  typedef struct {
      BOOL mld_enable;
      UINT mld_id;
@@ -29,7 +37,7 @@ index 00134cc..34934c9 100644
  } __attribute__((packed)) wifi_mld_common_info_t;
  
  typedef struct {
-@@ -2867,6 +2870,14 @@ typedef struct {
+@@ -2867,6 +2871,14 @@ typedef struct {
  } __attribute__((packed)) wifi_back_haul_sta_t;
  
  #define WIFI_AP_MAX_SSID_LEN    33
@@ -44,7 +52,7 @@ index 00134cc..34934c9 100644
  typedef struct {
      CHAR    ssid[WIFI_AP_MAX_SSID_LEN];
      BOOL    enabled;
-@@ -2894,6 +2905,8 @@ typedef struct {
+@@ -2894,6 +2906,8 @@ typedef struct {
      mac_address_t bssid;                    /**< The BSSID. This variable should only be used in the get API. It can't used to change the interface MAC */
      UINT   wmmNoAck;
      UINT   wepKeyLength;
@@ -53,7 +61,7 @@ index 00134cc..34934c9 100644
      BOOL   bssHotspot;
      UINT   wpsPushButton;
      char   beaconRateCtl[32];
-@@ -3055,4 +3068,4 @@ INT wifi_hal_analytics_callback_register(wifi_analytics_callback callback);
+@@ -3055,4 +3069,4 @@ INT wifi_hal_analytics_callback_register(wifi_analytics_callback callback);
  }
  #endif
  

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "ec5afd02d0d87613509b325a04fa0a2fe50636cb"
+SRCREV_rdk-wifi-hal = "e62398c723a9cc96ac6b62a5b35e29a49869de51"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY "
 CFLAGS_append_kirkstone = " -fcommon"
@@ -12,15 +12,18 @@ EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' BAN
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
-  file://InterfaceMap.json \
-  file://EasymeshCfg.json \
+  ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', bb.utils.contains('DISTRO_FEATURES', 'em_extender', 'file://InterfaceMap_em_ext.json ','file://InterfaceMap_em_ctrl.json ', d), 'file://InterfaceMap.json ', d)} \
+  ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', bb.utils.contains('DISTRO_FEATURES', 'em_extender', 'file://EasymeshCfg_ext.json ','file://EasymeshCfg.json ', d), ' ', d)} \
 "
 
 # Install InterfaceMap.json in /nvram
 do_install_append() {
   install -d ${D}/nvram
-  install -m 0644 ${WORKDIR}/InterfaceMap.json ${D}/nvram/InterfaceMap.json
-  install -m 0644 ${WORKDIR}/EasymeshCfg.json  ${D}/nvram 
+  install -m 0644 ${WORKDIR}/InterfaceMa*.json ${D}/nvram/InterfaceMap.json
+  DISTRO_EM_ENABLED="${@bb.utils.contains('DISTRO_FEATURES','EasyMesh','true','false',d)}"
+  if [ $DISTRO_EM_ENABLED = 'true' ]; then
+     install -m 0644 ${WORKDIR}/Easymesh*.json  ${D}/nvram/EasymeshCfg.json 
+  fi
 }
 
 FILES_${PN} += " \

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-util"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-util"
-SRCREV_rdk-wifi-util = "ec5afd02d0d87613509b325a04fa0a2fe50636cb"
+SRCREV_rdk-wifi-util = "e62398c723a9cc96ac6b62a5b35e29a49869de51"


### PR DESCRIPTION
Reason for change: Updated recipes with required changes to add systemd support and updated onewifi & dependent recipes with tip 
Test Procedure: At run-time, all processes are running during boot-up
Risks: Low