### PR TITLE
RDKBACCL-1013 : Need to remove maraidb dependency from Extender build

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/unified-wifi-mesh/unified-wifi-mesh-header.bb
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/unified-wifi-mesh/unified-wifi-mesh-header.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e0b1ae637439c7d6f4487fb90163c79a"
 
 SRC_URI = "git://github.com/rdkcentral/unified-wifi-mesh.git;branch=main;protocol=https;name=Unified-wifi-mesh_header"
 PV = "git${SRCPV}"
-SRCREV_Unified-wifi-mesh_header = "ed1964a5d69bd606c0a2068e2de0c6e428c76c16"
+SRCREV_Unified-wifi-mesh_header = "a74c2bc45342f2636992abecddbdae3ff6276a6b"
 SRCREV_FORMAT = "Unified-wifi-mesh_header"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Reason for change: Added below changes,
1. EM Agent have compile time dependency of mariadb but not runtime
2. updated srcrev in uwm 
Test procedure: Tested with daisy chain
Risks: None