### PR TITLE
RDKBACCL-870: Integrating "gw-lan-refresh" utility for banana pi

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/gw-lan-refresh/gw-lan-refresh.bb
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/gw-lan-refresh/gw-lan-refresh.bb
@@ -1,0 +1,31 @@
+SUMMARY = "GW LAN Refresh application for refreshing the LAN clients"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
+
+
+# Fetch the source code
+SRC_URI = "git://github.com/rdkcentral/broadband-utils.git;protocol=https;branch=develop"
+
+SRCREV = "8dc573c6b82ba5e164cf1287d4ab5c659bd38641"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "rdkb-halif-ethsw hal-ethsw rbus"
+
+
+LDFLAGS = " -lrbus -lhal_ethsw"
+CFLAGS = " \
+    -I${STAGING_INCDIR}/rbus \
+    -I${STAGING_INCDIR}/ccsp \
+"
+
+do_compile() {
+    ${CC} ${S}/gw-lan-refresh/source/*.c ${LDFLAGS} ${CFLAGS} -o gw_lan_refresh
+}
+
+do_install() {
+    # Create all directories first
+    install -d ${D}${bindir}
+    install -m 0755 gw_lan_refresh ${D}${bindir}/gw_lan_refresh
+}

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/gw_lan_refresh.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/gw_lan_refresh.patch
@@ -1,0 +1,39 @@
+Source: Prabhudas Gannavarapu <prabhudas_gannavarapu@comcast.com>
+Subject: Adding HAL changes for gw_lan_refresh application for Banana Pi R4
+
+Index: ethsw/rdkb_hal/src/ethsw/ccsp_hal_ethsw.c
+===================================================================
+--- ethsw.orig/rdkb_hal/src/ethsw/ccsp_hal_ethsw.c
++++ ethsw/rdkb_hal/src/ethsw/ccsp_hal_ethsw.c
+@@ -630,20 +634,9 @@ CcspHalEthSwSetPortAdminStatus
+     
+     char cmd1[32] = {0};
+     char cmd2[32] = {0};
+-    char interface[8] = {0};
+-    char path[32] = {0};
+-
+-    strcpy(path,"/sys/class/net/eth1");
+-
+-    int eth_if=is_interface_exists(path);
+-
+-    if(eth_if == 0 )
+-        return  RETURN_ERR;
+-
+-    strcpy(interface,"eth1");
+ 
+-    sprintf(cmd1,"ip link set %s up",interface);
+-    sprintf(cmd2,"ip link set %s down",interface);
++    sprintf(cmd1,"ip link set lan%d up",PortId);
++    sprintf(cmd2,"ip link set lan%d down",PortId);
+ 
+     switch (PortId)
+     {
+@@ -661,7 +654,7 @@ CcspHalEthSwSetPortAdminStatus
+                  }
+                  else
+                  {
+-                     //system(cmd2);
++                     system(cmd2);
+                      admin_status=1;
+                  }
+              }

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
@@ -1,3 +1,4 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 CFLAGS_append += " -D_PLATFORM_BANANAPI_R4_ "
 SRC_URI_append += "file://Add_interface_Changes.patch"
+SRC_URI_append += "file://gw_lan_refresh.patch"


### PR DESCRIPTION
Reason for change:
    Integrating gw_lan_refresh utility for banana pi.
Test Procedure:
    Execute gw_lan_refresh command from the device console and verify that lan ports are refreshing are not.
Risks: None