### PR TITLE
RDKBACCL-1026 : Add support with / without al-sap for EM

### DIFF
--- a/conf/distro/include/rdk-bpi-ap-extender.inc
+++ b/conf/distro/include/rdk-bpi-ap-extender.inc
@@ -24,6 +24,7 @@ DISTRO_FEATURES_append = " sdmmc"
 # Easymesh
 DISTRO_FEATURES_append = " EasyMesh"
 DISTRO_FEATURES_append = " sta_manager"
+#DISTRO_FEATURES_append = " with_alsap" 
 
 #PPP Feature
 #DISTRO_FEATURES_append = "ppp-enabled"

--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -47,6 +47,7 @@ DISTRO_FEATURES_remove = " lan0_as_wan"
 #Need to enable below distro once required changes are merged 
 #DISTRO_FEATURES_append = " EasyMesh"
 #DISTRO_FEATURES_append = " sta_manager"
+#DISTRO_FEATURES_append = " with_alsap"
 PREFERRED_VERSION_go = "1.24.%"
 
 #Enable wps support

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -28,4 +28,5 @@ add_busybox_fixes() {
 }
 
 IMAGE_INSTALL_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ppp-enabled', '', 'pptp-linux rp-pppoe xl2tpd', d)}"
-IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh',' unified-wifi-mesh unified-wifi-mesh-cli ieee1905-em socat','',d)}"
+IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh',' unified-wifi-mesh unified-wifi-mesh-cli socat','',d)}"
+IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'with_alsap',' ieee1905-em ','',d)}"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-ap-extender.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-ap-extender.bbappend
@@ -11,7 +11,7 @@ RDEPENDS_packagegroup-ap-extender = "\
     ccsp-psm \
     ccsp-psm-ccsp \
     unified-wifi-mesh \
-    ieee1905-em \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'with_alsap','ieee1905-em ','',d)} \
     bpi-macaddress \
     bpi-serialnumber \
 "

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -95,6 +95,15 @@ if [ "X$FEATURE_TYPE" == "XEasyMesh" ]; then
     sed -i '/sta_manager/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
 fi
 
+if [ "X$WITH_ALSAP" == "Xyes" ]; then
+    sed -i '/with_alsap/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
+    sed -i '/with_alsap/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi-ap-extender.inc
+fi
+
+if [ "X$FEATURE_TYPE" == "XEasyMesh" ] && [ "X$WITH_ALSAP" != "Xyes" ]; then
+    sed -i 's/$al_mac/$br_mac/g' ${_TOPDIR}/meta-cmf-broadband/recipes-ccsp/unified-wifi-mesh/files/setup_mysql_db_post.sh
+fi
+
 if [ "X$FEATURE_TYPE" == "XExtender2" ]; then
     cp ${_TOPDIR}/meta-cmf-bananapi/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em_ext1.json ${_TOPDIR}/meta-cmf-bananapi/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em_ext.json
     sed -i 's/wifi1.1 info/wifi0.1 info/g' ${_TOPDIR}/meta-cmf-bananapi/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ext.sh


### PR DESCRIPTION
Reason for change: Made necessary changes to add support of al-sap for  EM build  at build time
Test Procedure: Tested with daisy chain.
For Ext -
MACHINE=bananapi4-rdk-broadband-ap-extender WITH_ALSAP=yes source meta-cmf-bananapi/setup-environment-refboard-rdkb
For Ctrl/GW -
MACHINE=bananapi4-rdk-broadband FEATURE_TYPE=EasyMesh  WITH_ALSAP=yes source meta-cmf-bananapi/setup-environment-refboard-rdkb
AL_SAP is not compiled if we not set this option "WITH_ALSAP=yes " in machine command
Risks: Low