### PR TITLE
RDKBACCL-991: JSON Report upload is not working for both single & multi Telemetry Profiles

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-common/telemetry/telemetry_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-common/telemetry/telemetry_git.bbappend
@@ -1,0 +1,2 @@
+#RDKBACCL-991 we are not supporting mtls and its certificates in reference platform, removing the mtls enable flag
+CFLAGS_remove = "-DENABLE_MTLS"


### PR DESCRIPTION
Reason for change: we are not supporting mtls and its certificates in reference platform, removing the mtls enable flag
Test procedure: telemetry logupload should be success and json should get generated
Risks: None