### PR TITLE
RDKBACCL-945 - Psm bbhm file updates

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
@@ -215,7 +215,7 @@
   <Record name="eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.SsidUpgradeRequired" type="astr">1</Record>
 
  <!-- Ethernet interfaces of BananaPi Pi -->
-  <Record name="dmsb.ethagent.ethifcount" type="astr">1</Record>
+  <Record name="dmsb.ethagent.ethifcount" type="astr">4</Record>
 
   <Record name="dmsb.BridgeNamePrefix" type="astr">brlan</Record>
   <Record name="dmsb.bridgeVlanRange" type="astr">164...512</Record>

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
@@ -214,6 +214,9 @@
   <Record name="eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.Radio.2.FactoryResetSSID" type="astr">0</Record>
   <Record name="eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.SsidUpgradeRequired" type="astr">1</Record>
 
+ <!-- Ethernet interfaces of BananaPi Pi -->
+  <Record name="dmsb.ethagent.ethifcount" type="astr">1</Record>
+
   <Record name="dmsb.BridgeNamePrefix" type="astr">brlan</Record>
   <Record name="dmsb.bridgeVlanRange" type="astr">164...512</Record>
 


### PR DESCRIPTION
RDKBACCL-945 : Ping,FTP, HTTP, HTTPS, Telnet, TCP and UDP services working even when Device.Ethernet.Interface.1.Enable is disabled

Reason for change : Update the psm changes for the same
Test Procedure: Build and flash the image , test the dmcli 
Risks: None