### PR TITLE
RDKBACCL-1093: Core dump observed for Telcovoice component upon fetching Device. DM

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/fix_device_dm_taking_long_time.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/fix_device_dm_taking_long_time.patch
@@ -1,0 +1,37 @@
+diff --git a/config/RdkTelcoVoiceManager_v1.xml b/config/RdkTelcoVoiceManager_v1.xml
+index f07200a..b8c26d8 100644
+--- a/config/RdkTelcoVoiceManager_v1.xml
++++ b/config/RdkTelcoVoiceManager_v1.xml
+@@ -61,14 +61,16 @@
+                             <name>Voice</name>
+                             <objectType>object</objectType>
+                             <functions>
+-                                <func_GetParamUlongValue>X_RDK_Report_VoiceService_GetParamUlongValue</func_GetParamUlongValue>
++				    <!--
++				<func_GetParamUlongValue>X_RDK_Report_VoiceService_GetParamUlongValue</func_GetParamUlongValue>
+                                 <func_SetParamUlongValue>X_RDK_Report_VoiceService_SetParamUlongValue</func_SetParamUlongValue>
+                                 <func_GetParamStringValue>X_RDK_Report_VoiceService_GetParamStringValue</func_GetParamStringValue>
+                                 <func_GetParamBoolValue>X_RDK_Report_VoiceService_GetParamBoolValue</func_GetParamBoolValue>
+                                 <func_SetParamBoolValue>X_RDK_Report_VoiceService_SetParamBoolValue</func_SetParamBoolValue>
+                                 <func_Validate>X_RDK_Report_VoiceService_Validate</func_Validate>
+                                 <func_Commit>X_RDK_Report_VoiceService_Commit</func_Commit>
+-                                <func_Rollback>X_RDK_Report_VoiceService_Rollback</func_Rollback>
++				<func_Rollback>X_RDK_Report_VoiceService_Rollback</func_Rollback>
++				    -->
+                             </functions>
+                             <parameters>
+                                 <parameter>
+@@ -98,9 +100,11 @@
+                                 <object>
+                                     <name>Default</name>
+                                     <objectType>object</objectType>
+-                                    <functions>
++				    <functions>
++					    <!--
+                                         <func_GetParamUlongValue>X_RDK_Report_VoiceService_Default_GetParamUlongValue</func_GetParamUlongValue>
+-                                        <func_SetParamUlongValue>X_RDK_Report_VoiceService_Default_SetParamUlongValue</func_SetParamUlongValue>
++					<func_SetParamUlongValue>X_RDK_Report_VoiceService_Default_SetParamUlongValue</func_SetParamUlongValue>
++					    -->
+                                     </functions>
+                                     <parameters>
+                                         <parameter>

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdktelcovoicemanager.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdktelcovoicemanager.bbappend
@@ -1,0 +1,18 @@
+include ccsp_common_bananapi.inc
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://fix_device_dm_taking_long_time.patch;apply=no "
+
+do_voice_patch() {
+    cd ${S}
+    if [ ! -e bpi_voice_patch_applied ]; then
+        bbnote "Patching fix_device_dm_taking_long_time.patch"
+        patch -p1 < ${WORKDIR}/fix_device_dm_taking_long_time.patch
+
+       touch bpi_voice_patch_applied
+    fi
+}
+addtask voice_patch after do_unpack before do_compile
+
+INHIBIT_PACKAGE_STRIP = "1"


### PR DESCRIPTION
Reason for change:
    1)While fetching the DMs regarding reports core dump issue is observed.
    2)BPI currently not supporting harvester feature, commented out the functions which are causing the core dump issue.
Test Procedure:
    1) Execute "dmcli eRT getv Device."
    2) Core file shouldn't be generated regarding telcovoicemanager.
Risks: None