### PR TITLE
RDKBACCL-1024: populate SDK support in 6.6 kernel

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-kernel/linux/linux-firmware_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-kernel/linux/linux-firmware_%.bbappend
@@ -1,0 +1,7 @@
+#Remove duplicate package installation in populate sdk
+do_install_append() {
+                rm -rf ${D}${base_libdir}/firmware/mediatek/mt7996
+                rm -rf ${D}${base_libdir}/firmware/mediatek/mt7988
+                rm -rf ${D}${base_libdir}/firmware/mediatek/mt7996/mt7996*
+}
+

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -107,6 +107,7 @@ fi
 
 if [ "X$KERNEL_TYPE" == "Xkernel6-6" ]; then
     sed -i '/kernel6-6/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
+    echo 'RDEPENDS:${PN}-dev = ""' >> ${_TOPDIR}/meta-filogic/recipes-kernel/linux6-6-libc-headers/linux-libc-headers.inc
 fi
 
 if [ "X$BPI_IMG_TYPE" == "Xnand" ]; then


### PR DESCRIPTION
Reason for change: Resolved populate sdk build errors faced in kernel 6.6
Test Procedure: Image should bootup and populate sdk functionality should work
Risks: Low