### PR TITLE
RDKBACCL-1150 : observing build issues in latest wifiagent builds

### DIFF
--- a/conf/include/rdk-bpi-bbmasks.inc
+++ b/conf/include/rdk-bpi-bbmasks.inc
@@ -1,7 +1,6 @@
 BBMASK .= "|meta-cmf-filogic/recipes-extended/tdkb/"
 
 BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '|meta-filogic/recipes-wifi/hostapd/', '', d)}"
-BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '|meta-filogic/recipes-wifi/hal/halinterface.bbappend', '', d)}"
 BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '|meta-cmf-filogic/recipes-common/mesh-agent/mesh-agent.bbappend', '', d)}"
 
 BBMASK_append_kirkstone .= "|meta-rdk-opensync/recipes/python3-jinja2/python3-jinja2_2.11.1.bb"
@@ -12,3 +11,4 @@ BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES','EasyMesh','|openembedded-core
 BBMASK .= "${@bb.utils.contains('DISTRO_FEATURES','EasyMesh','|meta-cmf-filogic/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend','',d)}"
 BBMASK .= "|meta-cmf-filogic/recipes-ccsp/util/utopia-headers.bb"
 BBMASK .= "|meta-cmf-filogic/recipes-ccsp/hal/halinterface.bbappend"
+BBMASK .= "|meta-filogic/recipes-wifi/hal/halinterface.bbappend"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/0002-Add-EHT-support.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/0002-Add-EHT-support.patch
@@ -1,0 +1,17 @@
+SOURCE:mediatek
+
+diff --git a/include/wifi_hal_generic.h b/include/wifi_hal_generic.h
+index b81ad05..2a6f33e 100644
+--- a/include/wifi_hal_generic.h
++++ b/include/wifi_hal_generic.h
+@@ -328,7 +328,9 @@ typedef enum{
+     WIFI_CHANNELBANDWIDTH_80MHZ = 0x4,
+     WIFI_CHANNELBANDWIDTH_160MHZ = 0x8,
+     WIFI_CHANNELBANDWIDTH_80_80MHZ = 0x10,
+-    WIFI_CHANNELBANDWIDTH_320MHZ = 0x20
++    WIFI_CHANNELBANDWIDTH_320MHZ = 0x20,
++    WIFI_CHANNELBANDWIDTH_320_1MHZ = 0x40,
++    WIFI_CHANNELBANDWIDTH_320_2MHZ = 0x80
+ } wifi_channelBandwidth_t;
+ 
+ /**

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/sta-network-wifiagent.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/sta-network-wifiagent.patch
@@ -1,0 +1,113 @@
+From 68113170930788e52f8fa6089a2882dc28f5693f Mon Sep 17 00:00:00 2001
+From: Simon Chung <simon.c.chung@accenture.com>
+Date: Thu, 2 Sep 2021 15:44:57 +0100
+Subject: [PATCH] sta-network
+
+Change-Id: Idaae3038a352e94d1f2810a8d73b7f77c8e47309
+---
+ wifi_hal.h | 91 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 91 insertions(+)
+
+diff --git a/include/wifi_hal.h b/include/wifi_hal.h
+index 579418e..d284af4 100644
+--- a/include/wifi_hal.h
++++ b/include/wifi_hal.h
+@@ -110,4 +110,95 @@
+ * APIs to be deprecated. Not add new function or structure!
+ */
+ #include "wifi_hal_deprecated.h"
++
++/* DRAFT FOR CLIENT API */
++
++
++/* APPROACH 1*/
++typedef enum wifi_sta_network_flags {
++ WIFI_STA_NET_F_OPEN,
++ WIFI_STA_NET_F_PSK1,
++ WIFI_STA_NET_F_PSK2,WIFI_STA_NET_F_PSK_FT,
++ WIFI_STA_NET_F_AES,
++ WIFI_STA_NET_F_TKIP,
++ WIFI_STA_NET_F_4ADDR_MULTI_AP, /* future: easymesh's wds */
++ WIFI_STA_NET_F_OWE, /* future: opportunistic wireless encryption */
++ WIFI_STA_NET_F_SAE, /* future: wpa3 */
++} wifi_sta_network_flags_t;
++typedef enum wifi_sta_multi_ap_flag {
++ WIFI_STA_MULTI_AP_NOT_SUPPORTED,
++        WIFI_STA_MULTI_AP_NONE,
++        WIFI_STA_MULTI_AP_BHAUL_STA,
++} wifi_sta_multi_ap_flag_t;
++
++
++typedef struct wifi_sta_network {
++        int id;
++ char bridge[16]; /* valid for 4addr_multi_ap */
++ char ssid[32];
++ char psk[128];
++ char bssid[6]; /* 00:00:00:00:00:00 means any */
++ size_t ssid_len;
++ size_t psk_len;
++        int multi_ap;
++        char pairwise[64]; 
++        char proto[64];
++        char key_mgmt[64];
++ unsigned long flags; /* enum wifi_sta_network_flags */
++} wifi_sta_network_t;
++
++typedef struct wifi_sta_network_state {
++ struct wifi_sta_network desired_network;
++ char current_bssid[6]; /* 00:00:00:00:00:00 means disconnected */
++ int last_deauth_reason;
++ int last_disassoc_reason;
++} wifi_sta_network_state_t;
++
++typedef void (*wifi_sta_network_cb)(INT radioIndex, void *ctx);
++INT wifi_setStaNetwork(INT radioIndex, const wifi_sta_network_t *network);
++INT wifi_setStaNetworkSetEventCallback(INT radioIndex, wifi_sta_network_cb *cb, void *ctx);
++INT wifi_getStaNetworkState(INT radioIndex, wifi_sta_network_state_t *state);
++INT wifi_getStaNetworkCapabilities(INT radioIndex, INT *flags);
++
++/* APPROACH 2 */
++typedef struct {
++ CHAR ssid[33];
++ CHAR bssid[17];
++ CHAR passphrase[65];
++} wifi_staNetwork_t;
++
++INT wifi_getSTANetworks(INT apIndex, wifi_sta_network_t **out_staNetworks_array, INT out_array_size, BOOL *out_scan_cur_freq);
++
++INT wifi_setSTANetworks(INT apIndex, wifi_sta_network_t **staNetworks_array, INT array_size, BOOL scan_cur_freq);
++
++INT wifi_delSTANetworks(INT apIndex);
++
++
++/* notdefined approach */
++INT wifi_getSTANumberOfEntries(ULONG *output);
++INT wifi_getSTARadioIndex(INT ssidIndex, INT *radioIndex);
++INT wifi_getSTAName(INT apIndex, CHAR *output_string);
++INT wifi_getSTABSSID(INT ssidIndex, CHAR *output_string);
++INT wifi_getSTASSID(INT ssidIndex, CHAR *output_string);
++INT wifi_getSTAMAC(INT ssidIndex, CHAR *output_string);
++INT wifi_getSTAEnabled(INT ssidIndex, BOOL *enabled);
++INT wifi_setSTAEnabled(INT ssidIndex, BOOL enabled);
++
++typedef struct _wifi_client_associated_dev
++{
++        UCHAR MACAddress[6];                /**< The MAC address of an associated device. */
++        INT NetworkID;         /**< Network ID */
++        INT connected;         /**< If network is connected */
++        INT reason;
++        INT locally_generated;
++} wifi_client_associated_dev_t;       
++
++typedef INT ( * wifi_client_event_callback)(INT apIndex, wifi_client_associated_dev_t *state);
++
++void wifi_client_event_callback_register(wifi_client_event_callback callback_proc);
++INT wifi_getApChannel(INT radioIndex,ULONG *output_ulong);   //RDKB
++
++INT wifi_setApChannel(INT radioIndex, ULONG channel);        //RDKB  //AP only
++
++
+ #endif
+-- 
+2.28.0
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-halif.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-halif.bbappend
@@ -1,8 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+  
+SRC_URI_remove_onewifi = "git://github.com/rdkcentral/rdkb-halif-wifi.git;protocol=https;branch=main"
+SRC_URI_onewifi = "git://github.com/rdkcentral/rdkb-halif-wifi.git;protocol=https;branch=develop"
+SRCREV_onewifi = "33b416471090929422a0b03a6a76d5bf5a36eb3a"
 
-SRC_URI_remove = "git://github.com/rdkcentral/rdkb-halif-wifi.git;protocol=https;branch=main"
-SRC_URI += "git://github.com/rdkcentral/rdkb-halif-wifi.git;protocol=https;branch=develop"
-
-SRCREV = "33b416471090929422a0b03a6a76d5bf5a36eb3a"
-
-SRC_URI += "file://sta-network.patch"
+SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' ', ' file://sta-network-wifiagent.patch', d)}"
+SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' ', ' file://0002-Add-EHT-support.patch', d)}"
+SRC_URI_onewifi += " file://sta-network.patch"

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -90,6 +90,11 @@ sed -i '/python/d' ${_TOPDIR}/meta-cmf-filogic/recipes-core/images/image-exclude
 touch ${_TOPDIR}/meta-cmf-filogic/recipes-core/images/python_binary_removed
 fi
 
+if [ ! -e ${_TOPDIR}/meta-filogic/recipes-wifi/hal/mt76_hal_change ];then
+echo "DEPENDS += \"rdk-wifi-halif\"" >> ${_TOPDIR}/meta-filogic/recipes-wifi/hal/hal-wifi-mt76.bb
+echo "DEPENDS += \"rdk-wifi-halif\"" >> ${_TOPDIR}/meta-cmf-broadband/recipes-ccsp/hal/hal-wifi-cfg80211_git.bb
+touch ${_TOPDIR}/meta-filogic/recipes-wifi/hal/mt76_hal_change
+fi
 
 if [ "X$FEATURE_TYPE" == "XEasyMesh" ]; then
     sed -i '/EasyMesh/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc


### PR DESCRIPTION
Reason for change:  Added necessary changes in rdk-wifi-halif bbappend to make wifiagent build success
Test Procedure: Build successful
Risks: Low