### PR TITLE
RDKBACCL-1036: Remove openwrt pieces in our rdk-b banana pi

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
@@ -1,12 +1,6 @@
-<<<<<<< HEAD
-DEPENDS_remove = "ubus"
-EXTRA_OECMAKE += " \
-    -DUBUS_SUPPORT=OFF \
-=======
 DEPENDS_remove = "ubus uci"
 EXTRA_OECMAKE += " \
     -DUBUS_SUPPORT=OFF \
     -DUCI_SUPPORT=OFF \
->>>>>>> fc2be91 (RDKBACCL-1036: Remove the openwrt pieces in our rdk-b banana pi)
 "
 

--- a/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
@@ -1,5 +1,12 @@
+<<<<<<< HEAD
 DEPENDS_remove = "ubus"
 EXTRA_OECMAKE += " \
     -DUBUS_SUPPORT=OFF \
+=======
+DEPENDS_remove = "ubus uci"
+EXTRA_OECMAKE += " \
+    -DUBUS_SUPPORT=OFF \
+    -DUCI_SUPPORT=OFF \
+>>>>>>> fc2be91 (RDKBACCL-1036: Remove the openwrt pieces in our rdk-b banana pi)
 "
 

--- a/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
@@ -1,0 +1,5 @@
+DEPENDS_remove = "ubus"
+EXTRA_OECMAKE += " \
+    -DUBUS_SUPPORT=OFF \
+"
+

--- a/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/files/0001-remove-ubus-from-rdkb.patch
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/files/0001-remove-ubus-from-rdkb.patch
@@ -1,0 +1,53 @@
+diff --git a/wpa_supplicant/wpa_supplicant.c b/wpa_supplicant/wpa_supplicant.c
+index da471c9b8..a1a442403 100644
+--- a/wpa_supplicant/wpa_supplicant.c
++++ b/wpa_supplicant/wpa_supplicant.c
+@@ -7999,7 +7999,7 @@ struct wpa_supplicant * wpa_supplicant_add_iface(struct wpa_global *global,
+ 	}
+ #endif /* CONFIG_P2P */
+ 
+-	wpas_ubus_add_bss(wpa_s);
++	//wpas_ubus_add_bss(wpa_s);
+ 	wpas_ucode_add_bss(wpa_s);
+ 
+ 	return wpa_s;
+@@ -8029,7 +8029,7 @@ int wpa_supplicant_remove_iface(struct wpa_global *global,
+ #endif /* CONFIG_MESH */
+ 
+ 	wpas_ucode_free_bss(wpa_s);
+-	wpas_ubus_free_bss(wpa_s);
++	//wpas_ubus_free_bss(wpa_s);
+ 
+ 	/* Remove interface from the global list of interfaces */
+ 	prev = global->ifaces;
+diff --git a/wpa_supplicant/wpa_supplicant_i.h b/wpa_supplicant/wpa_supplicant_i.h
+index 1c1e69d3b..3532b5803 100644
+--- a/wpa_supplicant/wpa_supplicant_i.h
++++ b/wpa_supplicant/wpa_supplicant_i.h
+@@ -21,7 +21,7 @@
+ #include "config_ssid.h"
+ #include "wmm_ac.h"
+ #include "pasn/pasn_common.h"
+-#include "ubus.h"
++//#include "ubus.h"
+ #include "ucode.h"
+ 
+ extern const char *const wpa_supplicant_version;
+@@ -322,7 +322,7 @@ struct wpa_global {
+ 
+ 	struct psk_list_entry *add_psk; /* From group formation */
+ 
+-	struct ubus_object ubus_global;
++	//struct ubus_object ubus_global;
+ };
+ 
+ 
+@@ -697,7 +697,7 @@ struct wpa_supplicant {
+ 	unsigned char own_addr[ETH_ALEN];
+ 	unsigned char perm_addr[ETH_ALEN];
+ 	char ifname[100];
+-	struct wpas_ubus_bss ubus;
++	//struct wpas_ubus_bss ubus;
+ 	struct wpas_ucode_bss ucode;
+ #ifdef CONFIG_MATCH_IFACE
+ 	int matched;

--- a/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,5 +1,16 @@
 EXTRA_OEMAKE = "CONFIG_BUILD_WPA_CLIENT_SO=y"
 FILES_SOLIBSDEV = ""
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI += "file://0001-remove-ubus-from-rdkb.patch;apply=no"
+do_apply_patch() {
+    cd ${S}
+    patch -p1 < ${WORKDIR}/0001-remove-ubus-from-rdkb.patch
+}
+addtask apply_patch after do_configure before do_compile 
+do_configure:append() {
+    sed -i 's/^CONFIG_UBUS=y/# CONFIG_UBUS is not set/' ${S}/wpa_supplicant/.config
+    sed -i 's/^CONFIG_UCODE=y/# CONFIG_UCODE is not set/' ${S}/wpa_supplicant/.config
+}
 do_install_append () {
 	install -d ${D}${includedir}
 	install -d ${D}${libdir}
@@ -14,3 +25,5 @@ FILES_${PN} += "${includedir}/wpa_ctrl.h"
 FILES_${PN} += "lib/rdk"
 FILES_${PN} += " /usr/local"
 FILES:${PN}-dbg += " /usr/local/"
+DEPENDS_remove += "ubus udebug"
+

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -3,6 +3,13 @@ IMAGE_INSTALL_append = " parodus parodus2ccsp"
 
 #TR069 Feature
 IMAGE_INSTALL_append = " ccsp-tr069-pa"
+IMAGE_INSTALL_append = " bpi-serialnumber"
+IMAGE_INSTALL_append = " bpi-macaddress"
+
+
+IMAGE_INSTALL_append = " rdk-speedtest-cli"
+#Enable required linux utils for Fwupgrade
+IMAGE_INSTALL_append = " gptfdisk e2fsprogs-mke2fs"
 
 ROOTFS_POSTPROCESS_COMMAND_append = "add_busybox_fixes; "
 
@@ -19,3 +26,44 @@ add_busybox_fixes() {
 			cd -
                 fi
 }
+
+do_filogic_gen_image(){
+        if ${@bb.utils.contains('DISTRO_FEATURES','kernel_in_ubi','true','false',d)}; then
+        # create sysupgrade image align to openwrt
+                rm -rf ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}
+                rm -rf ${IMGDEPLOYDIR}/${PN}-${MACHINE}-sysupgrade.bin
+
+                mkdir ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}
+
+                cp ${DEPLOY_DIR_IMAGE}/fitImage ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/kernel
+                cp ${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/root
+                if ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','true','false',d)}; then
+                fit-rootfs-hash-tool ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/kernel ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/root
+                fi
+                cd ${IMGDEPLOYDIR}
+                tar cvf ${PN}-${MACHINE}-sysupgrade.bin sysupgrade-${PN}-${MACHINE}
+                mv ${PN}-${MACHINE}-sysupgrade.bin ${DEPLOY_DIR_IMAGE}/
+        if ${@bb.utils.contains('DISTRO_FEATURES','secure_boot','true','false',d)}; then
+
+                rm -rf ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb
+                rm -rf ${IMGDEPLOYDIR}/${PN}-${MACHINE}-sb-sysupgrade.bin
+
+                mkdir ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb
+
+                cp ${DEPLOY_DIR_IMAGE}/fitImage-sb ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/kernel
+                cp ${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/root
+                if ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','true','false',d)}; then
+                fit-rootfs-hash-tool ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/kernel ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/root
+                fi
+
+                cd ${IMGDEPLOYDIR}
+                tar cvf ${PN}-${MACHINE}-sb-sysupgrade.bin sysupgrade-${PN}-${MACHINE}-sb
+                mv ${PN}-${MACHINE}-sb-sysupgrade.bin ${DEPLOY_DIR_IMAGE}/
+        fi
+    fi
+}
+
+IMAGE_INSTALL_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ppp-enabled', '', 'pptp-linux rp-pppoe xl2tpd', d)}"
+IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh',' unified-wifi-mesh unified-wifi-mesh-cli socat','',d)}"
+IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'with_alsap',' ieee1905-em ','',d)}"
+IMAGE_INSTALL_remove += " mtkhnat-util"

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -3,13 +3,6 @@ IMAGE_INSTALL_append = " parodus parodus2ccsp"
 
 #TR069 Feature
 IMAGE_INSTALL_append = " ccsp-tr069-pa"
-IMAGE_INSTALL_append = " bpi-serialnumber"
-IMAGE_INSTALL_append = " bpi-macaddress"
-
-
-IMAGE_INSTALL_append = " rdk-speedtest-cli"
-#Enable required linux utils for Fwupgrade
-IMAGE_INSTALL_append = " gptfdisk e2fsprogs-mke2fs"
 
 ROOTFS_POSTPROCESS_COMMAND_append = "add_busybox_fixes; "
 
@@ -27,43 +20,4 @@ add_busybox_fixes() {
                 fi
 }
 
-do_filogic_gen_image(){
-        if ${@bb.utils.contains('DISTRO_FEATURES','kernel_in_ubi','true','false',d)}; then
-        # create sysupgrade image align to openwrt
-                rm -rf ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}
-                rm -rf ${IMGDEPLOYDIR}/${PN}-${MACHINE}-sysupgrade.bin
-
-                mkdir ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}
-
-                cp ${DEPLOY_DIR_IMAGE}/fitImage ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/kernel
-                cp ${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/root
-                if ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','true','false',d)}; then
-                fit-rootfs-hash-tool ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/kernel ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/root
-                fi
-                cd ${IMGDEPLOYDIR}
-                tar cvf ${PN}-${MACHINE}-sysupgrade.bin sysupgrade-${PN}-${MACHINE}
-                mv ${PN}-${MACHINE}-sysupgrade.bin ${DEPLOY_DIR_IMAGE}/
-        if ${@bb.utils.contains('DISTRO_FEATURES','secure_boot','true','false',d)}; then
-
-                rm -rf ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb
-                rm -rf ${IMGDEPLOYDIR}/${PN}-${MACHINE}-sb-sysupgrade.bin
-
-                mkdir ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb
-
-                cp ${DEPLOY_DIR_IMAGE}/fitImage-sb ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/kernel
-                cp ${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/root
-                if ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','true','false',d)}; then
-                fit-rootfs-hash-tool ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/kernel ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/root
-                fi
-
-                cd ${IMGDEPLOYDIR}
-                tar cvf ${PN}-${MACHINE}-sb-sysupgrade.bin sysupgrade-${PN}-${MACHINE}-sb
-                mv ${PN}-${MACHINE}-sb-sysupgrade.bin ${DEPLOY_DIR_IMAGE}/
-        fi
-    fi
-}
-
-IMAGE_INSTALL_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ppp-enabled', '', 'pptp-linux rp-pppoe xl2tpd', d)}"
-IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh',' unified-wifi-mesh unified-wifi-mesh-cli socat','',d)}"
-IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'with_alsap',' ieee1905-em ','',d)}"
 IMAGE_INSTALL_remove += " mtkhnat-util"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-logan.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-logan.bbappend
@@ -1,0 +1,4 @@
+RDEPENDS_packagegroup-filogic-logan_remove += " iwinfo \
+                                             uci \
+					ubus \
+"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
@@ -2,4 +2,10 @@ RDEPENDS_packagegroup-filogic-mt76_remove_onewifi = " \
                     hostapd \
                     usteer \
                     wifi-test-tool \
+                    vts \
+"
+RDEPENDS_packagegroup-filogic-mt76_remove_broadband = " mt76-test"
+RDEPENDS_packagegroup-filogic-mt76_remove += " iwinfo \
+                                          uci \
+					ubus \
 "


### PR DESCRIPTION
reason for change: Openwrt pieces like uci and ubus not required in our rdk-b banana pi
Test Procedure: Image should bootup and WebUI, Wi-Fi, and network functionalities work normally
Risks: Low