### PR TITLE
RDKBACCL-1036: Remove openwrt pieces in our rdk-b banana pi

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-bsp/trusted-firmware-a/bootloader_prebuild.bb
+++ b/meta-rdk-mtk-bpir4/recipes-bsp/trusted-firmware-a/bootloader_prebuild.bb
@@ -18,11 +18,15 @@ do_configure[noexec] = "1"
 RDEPENDS_${PN}-dev = ""
 
 SRC_URI_append += " file://bpi-r4_sdmmc_bl2.img \
-                    file://bpi-r4_sdmmc_fip.bin"
+                    file://bpi-r4_sdmmc_fip.bin \
+                    file://bpi-r4_sdmmc_bl2_B.img \
+                    file://bpi-r4_sdmmc_fip_B.bin"
 
 do_deploy() {
         mkdir -p ${DEPLOYDIR}/atf/
         install -m 0644 ${WORKDIR}/bpi-r4_sdmmc_bl2.img ${DEPLOYDIR}/atf/
+        install -m 0644 ${WORKDIR}/bpi-r4_sdmmc_bl2_B.img ${DEPLOYDIR}/atf/
         install -m 0644 ${WORKDIR}/bpi-r4_sdmmc_fip.bin ${DEPLOYDIR}/atf/
+        install -m 0644 ${WORKDIR}/bpi-r4_sdmmc_fip_B.bin ${DEPLOYDIR}/atf/
 }
 addtask do_deploy after do_install

--- a/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
@@ -1,0 +1,6 @@
+DEPENDS_remove = "ubus uci"
+EXTRA_OECMAKE += " \
+    -DUBUS_SUPPORT=OFF \
+    -DUCI_SUPPORT=OFF \
+"
+

--- a/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/files/0001-remove-ubus-on-rdkb.patch
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/files/0001-remove-ubus-on-rdkb.patch
@@ -1,0 +1,53 @@
+diff --git a/wpa_supplicant/wpa_supplicant.c b/wpa_supplicant/wpa_supplicant.c
+index da471c9b8..a1a442403 100644
+--- a/wpa_supplicant/wpa_supplicant.c
++++ b/wpa_supplicant/wpa_supplicant.c
+@@ -7999,7 +7999,7 @@ struct wpa_supplicant * wpa_supplicant_add_iface(struct wpa_global *global,
+ 	}
+ #endif /* CONFIG_P2P */
+ 
+-	wpas_ubus_add_bss(wpa_s);
++	//wpas_ubus_add_bss(wpa_s);
+ 	wpas_ucode_add_bss(wpa_s);
+ 
+ 	return wpa_s;
+@@ -8029,7 +8029,7 @@ int wpa_supplicant_remove_iface(struct wpa_global *global,
+ #endif /* CONFIG_MESH */
+ 
+ 	wpas_ucode_free_bss(wpa_s);
+-	wpas_ubus_free_bss(wpa_s);
++	//wpas_ubus_free_bss(wpa_s);
+ 
+ 	/* Remove interface from the global list of interfaces */
+ 	prev = global->ifaces;
+diff --git a/wpa_supplicant/wpa_supplicant_i.h b/wpa_supplicant/wpa_supplicant_i.h
+index 1c1e69d3b..3532b5803 100644
+--- a/wpa_supplicant/wpa_supplicant_i.h
++++ b/wpa_supplicant/wpa_supplicant_i.h
+@@ -21,7 +21,7 @@
+ #include "config_ssid.h"
+ #include "wmm_ac.h"
+ #include "pasn/pasn_common.h"
+-#include "ubus.h"
++//#include "ubus.h"
+ #include "ucode.h"
+ 
+ extern const char *const wpa_supplicant_version;
+@@ -322,7 +322,7 @@ struct wpa_global {
+ 
+ 	struct psk_list_entry *add_psk; /* From group formation */
+ 
+-	struct ubus_object ubus_global;
++	//struct ubus_object ubus_global;
+ };
+ 
+ 
+@@ -697,7 +697,7 @@ struct wpa_supplicant {
+ 	unsigned char own_addr[ETH_ALEN];
+ 	unsigned char perm_addr[ETH_ALEN];
+ 	char ifname[100];
+-	struct wpas_ubus_bss ubus;
++	//struct wpas_ubus_bss ubus;
+ 	struct wpas_ucode_bss ucode;
+ #ifdef CONFIG_MATCH_IFACE
+ 	int matched;

--- a/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,5 +1,16 @@
 EXTRA_OEMAKE = "CONFIG_BUILD_WPA_CLIENT_SO=y"
 FILES_SOLIBSDEV = ""
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI += "file://0001-remove-ubus-on-rdkb.patch;apply=no"
+do_apply_patch() {
+    cd ${S}
+    patch -p1 < ${WORKDIR}/0001-remove-ubus-on-rdkb.patch
+}
+addtask apply_patch after do_configure before do_compile 
+do_configure:append() {
+    sed -i 's/^CONFIG_UBUS=y/# CONFIG_UBUS is not set/' ${S}/wpa_supplicant/.config
+    sed -i 's/^CONFIG_UCODE=y/# CONFIG_UCODE is not set/' ${S}/wpa_supplicant/.config
+}
 do_install_append () {
 	install -d ${D}${includedir}
 	install -d ${D}${libdir}
@@ -14,3 +25,5 @@ FILES_${PN} += "${includedir}/wpa_ctrl.h"
 FILES_${PN} += "lib/rdk"
 FILES_${PN} += " /usr/local"
 FILES:${PN}-dbg += " /usr/local/"
+DEPENDS_remove += "ubus udebug"
+

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -29,4 +29,5 @@ add_busybox_fixes() {
 
 IMAGE_INSTALL_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ppp-enabled', '', 'pptp-linux rp-pppoe xl2tpd', d)}"
 IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh',' unified-wifi-mesh unified-wifi-mesh-cli socat','',d)}"
-IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'with_alsap',' ieee1905-em ','',d)}"
+IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'with_alsap',' ieee1905-em ','',d)}
+IMAGE_INSTALL_remove += " mtkhnat-util"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-logan.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-logan.bbappend
@@ -1,0 +1,4 @@
+RDEPENDS_packagegroup-filogic-logan_remove += " iwinfo \
+                                             uci \
+					ubus \
+"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
@@ -5,3 +5,7 @@ RDEPENDS_packagegroup-filogic-mt76_remove_onewifi = " \
                     vts \
 "
 RDEPENDS_packagegroup-filogic-mt76_remove_broadband = " mt76-test"
+RDEPENDS_packagegroup-filogic-mt76_remove += " iwinfo \
+                                          uci \
+					ubus \
+"

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -99,12 +99,12 @@ if [ "X$BPI_IMG_TYPE" == "Xnand" ]; then
     sed -i '/sdmmc/s/^/#/' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
 else # SD card image is default
     mkdir -p ${_TOPDIR}/downloads
-    if [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_bl2.img ] && [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_fip.bin ]; then
+    if [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_bl2.img ] && [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_fip.bin ] && [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_bl2_B.img ] && [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_fip_B.bin ]; then
         echo "Both bl2 and fip binaries are present in local workspace."
     else
         echo "**********************************************************************"
         echo "> CAUTION: YOU ARE TRYING TO BUILD SD CARD IMAGE WITHOUT BL2 AND FIP BINARIES."
-        echo "> Please download the binaries from https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_bl2.img and https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_fip.bin"
+	echo "> Please download the binaries from https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_bl2.img, https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_fip.bin, https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_bl2_B.img and https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_fip_B.bin"
         echo "> If you don't have access to above resources, please follow instruction in https://wiki.rdkcentral.com/pages/viewpage.action?pageId=354648448#SDMonoliticimagebuildandflashingstepsforBPIR4.-Buildingbl2.imgandfip.binincaseofnothavingaccesstoartifactoryrepository to build bl2 and fip binaries yourselves."
         echo "> Place those binaries under ${_TOPDIR}/downloads/"
         echo "> EXITING NOW."

--- a/wic/sdimage-Bananapi.wks
+++ b/wic/sdimage-Bananapi.wks
@@ -22,7 +22,7 @@ part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2_B.img" --part-na
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip_B.bin" --part-name fip_b --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 7. Boot B
-part /boot_b --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 8. rootfs B
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_b --fixed-size 512M

--- a/wic/sdimage-Bananapi.wks
+++ b/wic/sdimage-Bananapi.wks
@@ -10,10 +10,10 @@ part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2.img" --part-name
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip.bin" --part-name fip --align 6656 --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 3. Boot A
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_a --active --align 8704 --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_a --active --align 8704 --fixed-size 16M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 4. rootfs A
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_a --align 111104 --fixed-size 512M
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_a --fixed-size 1024M
 
 # 5. BL2 B (copy of BL2)
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2_B.img" --part-name bl2_b --fixed-size 4079K --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
@@ -22,35 +22,21 @@ part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2_B.img" --part-na
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip_B.bin" --part-name fip_b --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 7. Boot B
-part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 16M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 # 8. rootfs B
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_b --fixed-size 512M
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_b --fixed-size 1024M
 
-# 9. MAC A (512KB)
-part --source=empty --label=mac_a --fixed-size=512K
+# 9. NVRAM (2MB)
+part --source=empty --fstype=ext4 --label=nvram --fixed-size=2M
 
-# 10. NVRAM A (2MB)
-part --source=empty --fstype=ext4 --label=nvram_a --fixed-size=2M
-
-# 11. Crash Debug A (8MB)
+# 10. Crash Debug (8MB)
 part --source=empty --fstype=ext4 --label=crash_a --fixed-size=8M
-
-# 12. MAC B (512KB)
-part --source=empty --label=mac_b --fixed-size=512K
-
-# 13. NVRAM B (2MB)
-part --source=empty --fstype=ext4 --label=nvram_b --fixed-size=2M
-
-# 14. Crash Debug B (8MB)
 part --source=empty --fstype=ext4 --label=crash_b --fixed-size=8M
 
-# 15. Reserved (16MB)
+# 11. Reserved (16MB)
 part --source=empty --fstype=ext4 --label=reserved --fixed-size=16M
 
-# 16. Staging (256MB)
-part --source=empty --fstype=ext4 --label=staging --fixed-size=256M
-
-# 17. DAC (256MB)
-part --source=empty --fstype=ext4 --label=dac --fixed-size=256M
+# 12. DAC 
+part --source=empty --fstype=ext4 --label=dac --fixed-size=32M
 

--- a/wic/sdimage-Bananapi.wks
+++ b/wic/sdimage-Bananapi.wks
@@ -1,12 +1,56 @@
-# short-description: Create Bananapi Pi SD card image
-# long-description: Creates a partitioned SD card image for use with Bananapi R4.
+# short-description: Custom Bananapi R4 SD card image
+# long-description: Creates a partitioned SD card image with dual-bank layout and additional RDK-B partitions.
 
 bootloader --ptable gpt --timeout=0
 
+# 1. BL2 (aligned at 17 sectors, 4079KB)
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2.img" --part-name bl2 --align 17 --fixed-size 4079K --active --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
+# 2. FIP (aligned at 6656 sectors, 2048KB)
 part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip.bin" --part-name fip --align 6656 --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 8704 --fixed-size 100M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+# 3. Boot A
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_a --active --align 8704 --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 111104
+# 4. rootfs A
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_a --align 111104 --fixed-size 512M
+
+# 5. BL2 B (copy of BL2)
+part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2_B.img" --part-name bl2_b --fixed-size 4079K --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+
+# 6. FIP B (copy of FIP)
+part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip_B.bin" --part-name fip_b --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+
+# 7. Boot B
+part /boot_b --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot_b --active --fixed-size 128M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+
+# 8. rootfs B
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_b --fixed-size 512M
+
+# 9. MAC A (512KB)
+part --source=empty --label=mac_a --fixed-size=512K
+
+# 10. NVRAM A (2MB)
+part --source=empty --fstype=ext4 --label=nvram_a --fixed-size=2M
+
+# 11. Crash Debug A (8MB)
+part --source=empty --fstype=ext4 --label=crash_a --fixed-size=8M
+
+# 12. MAC B (512KB)
+part --source=empty --label=mac_b --fixed-size=512K
+
+# 13. NVRAM B (2MB)
+part --source=empty --fstype=ext4 --label=nvram_b --fixed-size=2M
+
+# 14. Crash Debug B (8MB)
+part --source=empty --fstype=ext4 --label=crash_b --fixed-size=8M
+
+# 15. Reserved (16MB)
+part --source=empty --fstype=ext4 --label=reserved --fixed-size=16M
+
+# 16. Staging (256MB)
+part --source=empty --fstype=ext4 --label=staging --fixed-size=256M
+
+# 17. DAC (256MB)
+part --source=empty --fstype=ext4 --label=dac --fixed-size=256M
+


### PR DESCRIPTION
reason for change: Openwrt pieces like uci and ubus not required in our rdk-b banana pi
Test Procedure: Image should bootup and WebUI, Wi-Fi, and network functionalities work normally
Risks: Low