### PR TITLE
RDKBACCL-1036: Remove openwrt pieces in our rdk-b banana pi

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
@@ -1,0 +1,5 @@
+DEPENDS_remove = "ubus uci"
+EXTRA_OECMAKE += " \
+    -DUBUS_SUPPORT=OFF \
+    -DUCI_SUPPORT=OFF \
+"

--- a/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/files/0001-remove-ubus-on-rdkb.patch
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/files/0001-remove-ubus-on-rdkb.patch
@@ -1,0 +1,53 @@
+diff --git a/wpa_supplicant/wpa_supplicant.c b/wpa_supplicant/wpa_supplicant.c
+index da471c9b8..a1a442403 100644
+--- a/wpa_supplicant/wpa_supplicant.c
++++ b/wpa_supplicant/wpa_supplicant.c
+@@ -7999,7 +7999,7 @@ struct wpa_supplicant * wpa_supplicant_add_iface(struct wpa_global *global,
+ 	}
+ #endif /* CONFIG_P2P */
+ 
+-	wpas_ubus_add_bss(wpa_s);
++	//wpas_ubus_add_bss(wpa_s);
+ 	wpas_ucode_add_bss(wpa_s);
+ 
+ 	return wpa_s;
+@@ -8029,7 +8029,7 @@ int wpa_supplicant_remove_iface(struct wpa_global *global,
+ #endif /* CONFIG_MESH */
+ 
+ 	wpas_ucode_free_bss(wpa_s);
+-	wpas_ubus_free_bss(wpa_s);
++	//wpas_ubus_free_bss(wpa_s);
+ 
+ 	/* Remove interface from the global list of interfaces */
+ 	prev = global->ifaces;
+diff --git a/wpa_supplicant/wpa_supplicant_i.h b/wpa_supplicant/wpa_supplicant_i.h
+index 1c1e69d3b..3532b5803 100644
+--- a/wpa_supplicant/wpa_supplicant_i.h
++++ b/wpa_supplicant/wpa_supplicant_i.h
+@@ -21,7 +21,7 @@
+ #include "config_ssid.h"
+ #include "wmm_ac.h"
+ #include "pasn/pasn_common.h"
+-#include "ubus.h"
++//#include "ubus.h"
+ #include "ucode.h"
+ 
+ extern const char *const wpa_supplicant_version;
+@@ -322,7 +322,7 @@ struct wpa_global {
+ 
+ 	struct psk_list_entry *add_psk; /* From group formation */
+ 
+-	struct ubus_object ubus_global;
++	//struct ubus_object ubus_global;
+ };
+ 
+ 
+@@ -697,7 +697,7 @@ struct wpa_supplicant {
+ 	unsigned char own_addr[ETH_ALEN];
+ 	unsigned char perm_addr[ETH_ALEN];
+ 	char ifname[100];
+-	struct wpas_ubus_bss ubus;
++	//struct wpas_ubus_bss ubus;
+ 	struct wpas_ucode_bss ucode;
+ #ifdef CONFIG_MATCH_IFACE
+ 	int matched;

--- a/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,14 +1,24 @@
 EXTRA_OEMAKE = "CONFIG_BUILD_WPA_CLIENT_SO=y"
 FILES_SOLIBSDEV = ""
-do_install_append () {
-	install -d ${D}${includedir}
-	install -d ${D}${libdir}
-	install -d ${D}/lib/rdk/
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-	install -m 0777 ${S}/wpa_supplicant/libwpa_client.so  ${D}${libdir}/
-	install -m 0644 ${S}/src/common/wpa_ctrl.h ${D}${includedir}/
+DEPENDS_remove += "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'ubus udebug', '', d)}"
+SRC_URI_append = "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' file://0001-remove-ubus-on-rdkb.patch', '', d)}"
+do_configure:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'true', 'false', d)}; then
+        sed -i 's/^CONFIG_UBUS=y/# CONFIG_UBUS is not set/' ${S}/wpa_supplicant/.config
+        sed -i 's/^CONFIG_UCODE=y/# CONFIG_UCODE is not set/' ${S}/wpa_supplicant/.config
+    fi
 }
 
+do_install_append () {
+        install -d ${D}${includedir}
+        install -d ${D}${libdir}
+        install -d ${D}/lib/rdk/
+
+        install -m 0777 ${S}/wpa_supplicant/libwpa_client.so  ${D}${libdir}/
+        install -m 0644 ${S}/src/common/wpa_ctrl.h ${D}${includedir}/
+}
 FILES_${PN} += "${libdir}/libwpa_client.so"
 FILES_${PN} += "${includedir}/wpa_ctrl.h"
 FILES_${PN} += "lib/rdk"

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -66,3 +66,4 @@ do_filogic_gen_image(){
 IMAGE_INSTALL_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ppp-enabled', '', 'pptp-linux rp-pppoe xl2tpd', d)}"
 IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh',' unified-wifi-mesh unified-wifi-mesh-cli socat','',d)}"
 IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'with_alsap',' ieee1905-em ','',d)}"
+IMAGE_INSTALL_remove += " mtkhnat-util"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-logan.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-logan.bbappend
@@ -1,0 +1,4 @@
+RDEPENDS_packagegroup-filogic-logan_remove += " iwinfo \
+                                             uci \
+					ubus \
+"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
@@ -5,3 +5,7 @@ RDEPENDS_packagegroup-filogic-mt76_remove_onewifi = " \
                     vts \
 "
 RDEPENDS_packagegroup-filogic-mt76_remove_broadband = " mt76-test"
+RDEPENDS_packagegroup-filogic-mt76_remove += " iwinfo \
+                                          uci \
+					ubus \
+"


### PR DESCRIPTION
reason for change: Openwrt pieces like uci and ubus not required in our rdk-b banana pi
Test Procedure: Image should bootup and WebUI, Wi-Fi, and network functionalities work normally
Risks: Low