### PR TITLE
RDKBACCL-1153: Build 6.6 kernel Extender image

### DIFF
--- a/conf/distro/include/rdk-bpi-ap-extender.inc
+++ b/conf/distro/include/rdk-bpi-ap-extender.inc
@@ -31,3 +31,7 @@ DISTRO_FEATURES_append = " CONFIG_IEEE80211BE"
 DISTRO_FEATURES_append = " generic_mlo"
 #PPP Feature
 #DISTRO_FEATURES_append = "ppp-enabled"
+
+# Kernel 6.6
+#DISTRO_FEATURES_append = " kernel6-6"
+

--- a/conf/machine/bananapi4-rdk-broadband-ap-extender.conf
+++ b/conf/machine/bananapi4-rdk-broadband-ap-extender.conf
@@ -6,7 +6,7 @@
 
 RUST_PANIC_STRATEGY="abort"
 
-require conf/machine/filogic880-bpi-r4.conf
+require ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','conf/machine/filogic880-kernel6-6-bpi-r4.conf','conf/machine/filogic880-bpi-r4.conf',d)}
 DISTRO_FEATURES_append = " em_extender"
 require conf/distro/include/rdk-bpi-ap-extender.inc 
 PREFERRED_PROVIDER_hal-wifi_onewifi = "hal-wifi-generic"
@@ -15,10 +15,13 @@ MACHINE_IMAGE_NAME = "rdk-generic-ap-extender-image"
 #SDCARD supported changes.
 MACHINEOVERRIDES .="${@bb.utils.contains('DISTRO_FEATURES','sdmmc',':sd','',d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES','sdmmc','wic.bz2 ext4','',d)}"
-KERNEL_DEVICETREE_mt7988_bpi4_sd = "mediatek/mt7988a-bananapi-bpi-r4-sd.dtb"
+KERNEL_DEVICETREE_mt7988_bpi4_sd = "${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','mediatek/mt7988a-bananapi-bpi-r4.dtb','mediatek/mt7988a-bananapi-bpi-r4-sd.dtb', d)}"
 
 WKS_FILE = " ${@bb.utils.contains('DISTRO_FEATURES','EasyMesh',' sdimage-EM-Bananapi.wks',' sdimage-Bananapi.wks',d)}"
-IMAGE_BOOT_FILES = "${@bb.utils.contains('DISTRO_FEATURES','sdmmc','mt7988a-bananapi-bpi-r4-sd.dtb ${KERNEL_IMAGETYPE}','',d)}"
+IMAGE_BOOT_FILES = "${@bb.utils.contains('DISTRO_FEATURES','sdmmc', bb.utils.contains('DISTRO_FEATURES','kernel6-6','mt7988a-bananapi-bpi-r4.dtb ${KERNEL_IMAGETYPE}','mt7988a-bananapi-bpi-r4-sd.dtb ${KERNEL_IMAGETYPE}', d),'',d)}"
 do_image_wic[recrdeps] = "do_build"
 #SDCARD supported Pre build bootloader
 do_image_wic[depends] += " atf_bootloader_prebuild:do_deploy"
+
+#removing itb-image class for kernel6-6
+KERNEL_CLASSES_remove = "${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','itb-image','',d)}"

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-ap-extender-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-ap-extender-image.bbappend
@@ -27,7 +27,7 @@ SYSTEMD_TOOLS = "systemd-analyze systemd-bootchart"
 # systemd-bootchart doesn't currently build with musl libc
 SYSTEMD_TOOLS_remove_libc-musl = "systemd-bootchart"
 
-DEPENDS += "cryptsetup-native"
+DEPENDS += "cryptsetup-native fit-rootfs-hash-tool-native"
 
 IMAGE_INSTALL += " \
     ${SYSTEMD_TOOLS} \
@@ -59,7 +59,8 @@ IMAGE_INSTALL += " \
     strongswan \
     libpcap \
     tcpdump \
-    perf \
+    ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','linux-firmware-mt7988  linux-firmware-airoha fitblk','airoha-eth-firmware',d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','','perf',d)} \
     ${@bb.utils.contains('DISTRO_FEATURES','mt76','packagegroup-filogic-mt76','',d)} \
     ${@bb.utils.contains('DISTRO_FEATURES','em_extender','packagegroup-ap-extender','',d)} \
     ${@bb.utils.contains('DISTRO_FEATURES','logan','packagegroup-filogic-logan','',d)} \
@@ -113,6 +114,9 @@ do_filogic_gen_image(){
             cp ${DEPLOY_DIR_IMAGE}/fitImage ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/kernel
             cp ${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/root
 
+            if ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','true','false',d)}; then
+                fit-rootfs-hash-tool ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/kernel ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/root
+            fi
             cd ${IMGDEPLOYDIR}
             tar cvf ${PN}-${MACHINE}-sysupgrade.bin sysupgrade-${PN}-${MACHINE}
             mv ${PN}-${MACHINE}-sysupgrade.bin ${DEPLOY_DIR_IMAGE}/
@@ -128,6 +132,9 @@ do_filogic_gen_image(){
 
             cp ${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/root
 
+            if ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','true','false',d)}; then
+                fit-rootfs-hash-tool ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/kernel ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/root
+            fi
             cd ${IMGDEPLOYDIR}
 
             tar cvf ${PN}-${MACHINE}-sb-sysupgrade.bin sysupgrade-${PN}-${MACHINE}-sb

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -112,6 +112,7 @@ fi
 
 if [ "X$KERNEL_TYPE" == "Xkernel6-6" ]; then
     sed -i '/kernel6-6/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
+    sed -i '/kernel6-6/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi-ap-extender.inc
     echo 'RDEPENDS:${PN}-dev = ""' >> ${_TOPDIR}/meta-filogic/recipes-kernel/linux6-6-libc-headers/linux-libc-headers.inc
 fi
 


### PR DESCRIPTION
Reason for change : Upgrading from linux kernel 5.4 to 6.6 in BPI Extender build.
Test Procedure: BPI extender image should come up with 6.6 kernel.
Risks: None