### PR TITLE
RDKBACCL-1146  : Port Id Not taken correctly

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/Ethernet-Lan-changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/Ethernet-Lan-changes.patch
@@ -47,7 +47,7 @@ Index: ethsw/rdkb_hal/src/ethsw/ccsp_hal_ethsw.c
      memset(&ifr, 0, sizeof(ifr));
 -    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", "eth1");
 +    if (PortId == 1)
-+	       snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s" "erouter0");
++	       snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", "erouter0");
 +    else
 +        snprintf(ifr.ifr_name, sizeof(ifr.ifr_name),"lan%d",(PortId-1));
  

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/Ethernet-Lan-changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/Ethernet-Lan-changes.patch
@@ -47,9 +47,9 @@ Index: ethsw/rdkb_hal/src/ethsw/ccsp_hal_ethsw.c
      memset(&ifr, 0, sizeof(ifr));
 -    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", "eth1");
 +    if (PortId == 1)
-+	snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "erouter0");
++	       snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s" "erouter0");
 +    else
-+        snprintf(ifr.ifr_name, sizeof(ifr.ifr_name),"lan",(PortId-1));
++        snprintf(ifr.ifr_name, sizeof(ifr.ifr_name),"lan%d",(PortId-1));
  
      if (ioctl(sockfd, SIOCGIFFLAGS, &ifr) < 0)
      {


### PR DESCRIPTION
RDKBACCL-904 : Failed to Get the response of CcspHalEthSwGetPortAdminStatus for LAN Port 2
Reason for change : Syntax issue , corrected now 
Test Procedure: Build and flash the image , check the interface details
Risks: None