### PR TITLE
RDKBACCL-1148 : Default value of  WIFI_TELEMETRY.LogInterval

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
@@ -1281,4 +1281,5 @@
   <Record name="eRT.com.cisco.spvtg.ccsp.webpa.WebConfigRfcEnable" type="astr">true</Record>	 
   <!-- Default WPA3 transition start record -->
   <Record name="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.WPA3_Personal_Transition.Enable" type="astr">1</Record> 
+  <Record name="dmsb.device.deviceinfo.X_RDKCENTRAL-COM_WHIX.LogInterval" type="astr">3600</Record>	
 </Provision>


### PR DESCRIPTION
…nterval

RDKBACCL-1148 : X_RDKCENTRAL-COM_WIFI_TELEMETRY.LogInterval default value
Reason for change : Default value of X_RDKCENTRAL-COM_WIFI_TELEMETRY.LogInterval is not added in PSM
Test Procedure: Build and flash the image , Do FR and check the value
Risks: None


Parameter    1 name: Device.DeviceInfo.X_RDKCENTRAL-COM_WIFI_TELEMETRY.LogInterval
               type:        int,    value: 300

root@Filogic-GW:~#
root@Filogic-GW:~#
root@Filogic-GW:~# dmcli eRT setv Device.X_CISCO_COM_DeviceControl.FactoryReset string "Router,Wifi,VoIP,Dect,MoCA"
CR component name is: eRT.com.cisco.spvtg.ccsp.CR
subsystem_prefix eRT.
Execution succeed.



root@Filogic-GW:~# dmcli eRT getv Device.DeviceInfo.X_RDKCENTRAL-COM_WIFI_TELEMETRY.LogInterval
CR component name is: eRT.com.cisco.spvtg.ccsp.CR
subsystem_prefix eRT.
Execution succeed.
Parameter    1 name: Device.DeviceInfo.X_RDKCENTRAL-COM_WIFI_TELEMETRY.LogInterval
               type:        int,    value: 3600

