### PR TITLE
RDKBACCL-1177: Device is rebooting continuously after Factory Reset o…

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
@@ -1,1 +1,2 @@
 include ccsp_common_bananapi.inc
+SRC_URI:remove = "file://filogic-factoryReset.patch"


### PR DESCRIPTION
…n kernel 6.6 Image

Reason for change: Not creating reset-default on FR since UBI is not enabled to store default settings
Test procedure: Continuous reboot is not observed after FR 
Risks: Low