### PR TITLE
RDKBACCL-1200: Remove artifactory reference from setup-environment script

### DIFF
--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -123,15 +123,8 @@ else # SD card image is default
         echo "Both bl2 and fip binaries are present in local workspace."
     else
         echo "**********************************************************************"
-        echo "> CAUTION: YOU ARE TRYING TO BUILD SD CARD IMAGE WITHOUT BL2 AND FIP BINARIES."
-        if [ "X$KERNEL_TYPE" == "Xkernel6-6" ]; then
-             echo "> Please download the binaries from https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2025.01/bpi-r4_sdmmc_bl2.img and https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2025.01/bpi-r4_sdmmc_fip.bin"
-        else
-             echo "> Please download the binaries from https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_bl2.img and https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2024.04/bpi-r4_sdmmc_fip.bin"
-	fi
-        echo "> If you don't have access to above resources, please follow instruction in https://wiki.rdkcentral.com/pages/viewpage.action?pageId=354648448#SDMonoliticimagebuildandflashingstepsforBPIR4.-Buildingbl2.imgandfip.binincaseofnothavingaccesstoartifactoryrepository to build bl2 and fip binaries yourselves."
-        echo "> Place those binaries under ${_TOPDIR}/downloads/"
-        echo "> EXITING NOW."
+        echo "> Missing files are preventing the build from starting:"
+        echo "> The BL2 and FIP binaries aren't in the downloads directory. Copy these binaries into the directory and then restart the build. You can find instructions for creating the necessary binaries on the RDK-B Code Releases page: (https://wiki.rdkcentral.com/display/CMF/RDK-B+Code+Releases)"
         echo "**********************************************************************"
         return 1
     fi


### PR DESCRIPTION
Reason for Change: Removed artifactory references from the setup-environment script
Test Procedure: Verified that no artifactory references appear when the 'source' command is executed
Risks: Low