### PR TITLE
RDKBACCL-1197: Erouter0 is not getting IP in latest builds

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-connectivity/ucode/ucode_git.bbappend
@@ -1,5 +1,2 @@
-DEPENDS_remove = "ubus uci"
-EXTRA_OECMAKE += " \
-    -DUBUS_SUPPORT=OFF \
-    -DUCI_SUPPORT=OFF \
-"
+DEPENDS_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'ubus uci', '', d)}"
+EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '-DUBUS_SUPPORT=OFF -DUCI_SUPPORT=OFF', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -66,4 +66,4 @@ do_filogic_gen_image(){
 IMAGE_INSTALL_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ppp-enabled', '', 'pptp-linux rp-pppoe xl2tpd', d)}"
 IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh',' unified-wifi-mesh unified-wifi-mesh-cli socat','',d)}"
 IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'with_alsap',' ieee1905-em ','',d)}"
-IMAGE_INSTALL_remove += " mtkhnat-util"
+IMAGE_INSTALL_remove_onewifi += " mtkhnat-util"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-logan.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-logan.bbappend
@@ -1,4 +1,4 @@
-RDEPENDS_packagegroup-filogic-logan_remove += " iwinfo \
+RDEPENDS_packagegroup-filogic-logan_remove_onewifi += " iwinfo \
                                              uci \
 					ubus \
 "

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
@@ -3,9 +3,8 @@ RDEPENDS_packagegroup-filogic-mt76_remove_onewifi = " \
                     usteer \
                     wifi-test-tool \
                     vts \
+                    iwinfo \
+                    uci \
+                    ubus \
 "
 RDEPENDS_packagegroup-filogic-mt76_remove_broadband = " mt76-test"
-RDEPENDS_packagegroup-filogic-mt76_remove += " iwinfo \
-                                          uci \
-					ubus \
-"


### PR DESCRIPTION
Reason for Change: Enabled UCI support for wifiagent, handled distro specific to onewifi.
Test Procedure: Verified UCI support functionality during runtime
Risks: Low