### PR TITLE
RDKBACCL-771 : Wifi interfaces should have constant unique MAC for 6G

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ctrl.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ctrl.sh
@@ -9,6 +9,8 @@ iw phy phy0 interface add wifi1.1 type __ap
 iw phy phy0 interface add wifi1.2 type __ap
 iw phy phy0 interface add wifi1.3 type __ap
 iw phy phy0 interface add wifi2 type __ap
+iw phy phy0 interface add wifi2.1 type __ap
+iw phy phy0 interface add wifi2.2 type __ap
 iw phy phy0 interface add mld0 type __ap radios all
 
 #Obtain the wifi mac address
@@ -16,10 +18,12 @@ wifi0_mac=`cat /nvram/mac_addresses.txt | grep -a wifi0 | cut -d " " -f 2 | head
 wifi0_1_mac=`cat /nvram/mac_addresses.txt | grep -a wifi0.1 | cut -d " " -f 2 | head -n1`
 wifi0_2_mac=`cat /nvram/mac_addresses.txt | grep -a wifi0.2 | cut -d " " -f 2 | head -n1`
 wifi1_mac=`cat /nvram/mac_addresses.txt | grep -a wifi1 | cut -d " " -f 2 | head -n1`
-wifi2_mac=`cat /nvram/mac_addresses.txt | grep -a wifi2 | cut -d " " -f 2`
+wifi2_mac=`cat /nvram/mac_addresses.txt | grep -a wifi2 | cut -d " " -f 2 | head -n1`
 wifi1_1_mac=`cat /nvram/mac_addresses.txt | grep -a wifi1.1 | cut -d " " -f 2 | head -n1`
 wifi1_2_mac=`cat /nvram/mac_addresses.txt | grep -a wifi1.2 | cut -d " " -f 2 | head -n1`
 wifi1_3_mac=`cat /nvram/mac_addresses.txt | grep -a wifi1.3 | cut -d " " -f 2 | head -n1`
+wifi2_1_mac=`cat /nvram/mac_addresses.txt | grep -a wifi2.1 | cut -d " " -f 2 | head -n1`
+wifi2_2_mac=`cat /nvram/mac_addresses.txt | grep -a wifi2.2 | cut -d " " -f 2 | head -n1`
 
 #Update the mac address using ip link command
 ifconfig wifi0 down
@@ -30,6 +34,8 @@ ifconfig wifi1.1 down
 ifconfig wifi1.2 down
 ifconfig wifi1.3 down
 ifconfig wifi2 down
+ifconfig wifi2.1 down
+ifconfig wifi2.2 down
 
 ip link set dev wifi0 address $wifi0_mac
 ip link set dev wifi0.1 address $wifi0_1_mac
@@ -39,6 +45,8 @@ ip link set dev wifi1.1 address $wifi1_1_mac
 ip link set dev wifi1.2 address $wifi1_2_mac
 ip link set dev wifi1.3 address $wifi1_3_mac
 ip link set dev wifi2 address $wifi2_mac
+ip link set dev wifi2.1 address $wifi2_1_mac
+ip link set dev wifi2.2 address $wifi2_2_mac
 
 ifconfig wifi0 up
 ifconfig wifi0.1 up
@@ -48,6 +56,8 @@ ifconfig wifi1.1 up
 ifconfig wifi1.2 up
 ifconfig wifi1.3 up
 ifconfig wifi2 up
+ifconfig wifi2.1 up
+ifconfig wifi2.2 up
 
 # Set MLD interface address as wifi2 MAC address + 1
 prefix="${wifi2_mac%:*}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ext.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ext.sh
@@ -9,6 +9,8 @@ iw phy phy0 interface add wifi1.1 type __ap
 iw phy phy0 interface add wifi1.2 type __ap
 iw phy phy0 interface add wifi1.3 type __ap
 iw phy phy0 interface add wifi2 type __ap
+iw phy phy0 interface add wifi2.1 type __ap
+iw phy phy0 interface add wifi2.2 type __ap
 iw phy phy0 interface add mld0 type __ap radios all
 
 #Obtain the wifi mac address
@@ -16,10 +18,12 @@ wifi0_mac=`cat /nvram/mac_addresses.txt | grep -a wifi0 | cut -d " " -f 2 | head
 wifi0_1_mac=`cat /nvram/mac_addresses.txt | grep -a wifi0.1 | cut -d " " -f 2 | head -n1`
 wifi0_2_mac=`cat /nvram/mac_addresses.txt | grep -a wifi0.2 | cut -d " " -f 2 | head -n1`
 wifi1_mac=`cat /nvram/mac_addresses.txt | grep -a wifi1 | cut -d " " -f 2 | head -n1`
-wifi2_mac=`cat /nvram/mac_addresses.txt | grep -a wifi2 | cut -d " " -f 2`
+wifi2_mac=`cat /nvram/mac_addresses.txt | grep -a wifi2 | cut -d " " -f 2 | head -n1`
 wifi1_1_mac=`cat /nvram/mac_addresses.txt | grep -a wifi1.1 | cut -d " " -f 2 | head -n1`
 wifi1_2_mac=`cat /nvram/mac_addresses.txt | grep -a wifi1.2 | cut -d " " -f 2 | head -n1`
 wifi1_3_mac=`cat /nvram/mac_addresses.txt | grep -a wifi1.3 | cut -d " " -f 2 | head -n1`
+wifi2_1_mac=`cat /nvram/mac_addresses.txt | grep -a wifi2.1 | cut -d " " -f 2 | head -n1`
+wifi2_2_mac=`cat /nvram/mac_addresses.txt | grep -a wifi2.2 | cut -d " " -f 2 | head -n1`
 
 #Update the mac address using ip link command
 ifconfig wifi0 down
@@ -30,6 +34,8 @@ ifconfig wifi1.1 down
 ifconfig wifi1.2 down
 ifconfig wifi1.3 down
 ifconfig wifi2 down
+ifconfig wifi2.1 down
+ifconfig wifi2.2 down
 
 ip link set dev wifi0 address $wifi0_mac
 ip link set dev wifi0.1 address $wifi0_1_mac
@@ -39,6 +45,8 @@ ip link set dev wifi1.1 address $wifi1_1_mac
 ip link set dev wifi1.2 address $wifi1_2_mac
 ip link set dev wifi1.3 address $wifi1_3_mac
 ip link set dev wifi2 address $wifi2_mac
+ip link set dev wifi2.1 address $wifi2_1_mac
+ip link set dev wifi2.2 address $wifi2_2_mac
 
 ifconfig wifi0 up
 ifconfig wifi0.1 up
@@ -48,6 +56,8 @@ ifconfig wifi1.1 up
 ifconfig wifi1.2 up
 ifconfig wifi1.3 up
 ifconfig wifi2 up
+ifconfig wifi2.1 up
+ifconfig wifi2.2 up
 
 # Set MLD interface address as wifi2 MAC address + 1
 prefix="${wifi2_mac%:*}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em.json
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em.json
@@ -8,6 +8,20 @@
                     "RadioName": "wifi2",
                     "InterfaceList": [
                         {
+                            "InterfaceName": "wifi2.2",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 17,
+                            "vapName": "iot_ssid_6g"
+                        },
+                        {
+                            "InterfaceName": "wifi2.1",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 22,
+                            "vapName": "mesh_backhaul_6g"
+                        },
+                        {
                             "InterfaceName": "wifi2",
                             "Bridge": "brlan0",
                             "vlanId": 0,

--- a/meta-rdk-mtk-bpir4/recipes-extended/macaddress/bpi-macaddress.bb
+++ b/meta-rdk-mtk-bpir4/recipes-extended/macaddress/bpi-macaddress.bb
@@ -9,7 +9,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/broadband-utils;protocol=https;branch=develop"
 
 S = "${WORKDIR}/git"
 PV = "1.0.0"
-SRCREV = "e2060a77127aff5c2a49cb4b5957597acb642db2"
+SRCREV = "55d70f1560fc9092c037d869aae450524b5c6ae8"
 
 CXXFLAGS_append = "  -DAARCH64_BUILD"
 CXXFLAGS_append = "  ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', bb.utils.contains('DISTRO_FEATURES', 'em_extender', ' -D_EM_EXT_BUILD_ -D_EM_BUILD_ ',' -D_EM_BUILD_ ', d), ' ', d)}"


### PR DESCRIPTION
Reason for change:  updated bpi-macaddress srcrev and  added
    needed changes to get the BH,iot wifi interfaces for 6G band
Test Procedure: Basic EM test cases are passed
Risks: Low