### PR TITLE
RDKBACCL-1034 : Scarthgap - patch recreate for OSS build

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-devtools/libubox/files/0001-version-libraries-fix-libdir-scarthgap-updated.patch
+++ b/meta-rdk-mtk-bpir4/recipes-devtools/libubox/files/0001-version-libraries-fix-libdir-scarthgap-updated.patch
@@ -1,0 +1,54 @@
+[PATCH] fix the CMAKE_INSTALL_LIBDIR
+
+Upstream-Status: Pending
+
+libdir maybe /usr/lib64 for 64bit machine
+
+Signed-off-by: Roy Li <rongqing.li@windriver.com>
+---
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f40eaa6..783fa0a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,6 +21,7 @@ INCLUDE_DIRECTORIES(${JSONC_INCLUDE_DIRS})
+ SET(SOURCES avl.c avl-cmp.c blob.c blobmsg.c uloop.c usock.c ustream.c ustream-fd.c vlist.c utils.c safe_list.c runqueue.c md5.c kvlist.c ulog.c base64.c udebug.c udebug-remote.c)
+ 
+ ADD_LIBRARY(ubox SHARED ${SOURCES})
++SET_TARGET_PROPERTIES(ubox PROPERTIES VERSION 1.0.1 SOVERSION 1)
+ ADD_LIBRARY(ubox-static STATIC ${SOURCES})
+ SET_TARGET_PROPERTIES(ubox-static PROPERTIES OUTPUT_NAME ubox)
+ 
+@@ -41,8 +42,8 @@ INSTALL(FILES ${headers}
+ 	DESTINATION include/libubox
+ )
+ INSTALL(TARGETS ubox ubox-static
+-	ARCHIVE DESTINATION lib
+-	LIBRARY DESTINATION lib
++	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ )
+ 
+ ADD_SUBDIRECTORY(lua)
+@@ -65,6 +66,7 @@ find_library(json NAMES json-c)
+ IF(EXISTS ${json})
+ 	ADD_LIBRARY(blobmsg_json SHARED blobmsg_json.c)
+ 	TARGET_LINK_LIBRARIES(blobmsg_json ubox ${json})
++	SET_TARGET_PROPERTIES(blobmsg_json PROPERTIES VERSION 1.0.1 SOVERSION 1)
+ 
+ 	ADD_LIBRARY(blobmsg_json-static STATIC blobmsg_json.c)
+ 	SET_TARGET_PROPERTIES(blobmsg_json-static
+@@ -78,11 +80,12 @@ IF(EXISTS ${json})
+ 	TARGET_LINK_LIBRARIES(jshn blobmsg_json ${json})
+ 
+ 	ADD_LIBRARY(json_script SHARED json_script.c)
++	SET_TARGET_PROPERTIES(json_script PROPERTIES VERSION 1.0.1 SOVERSION 1)
+ 	TARGET_LINK_LIBRARIES(json_script ubox)
+ 
+ 	INSTALL(TARGETS blobmsg_json blobmsg_json-static jshn json_script
+-		ARCHIVE DESTINATION lib
+-		LIBRARY DESTINATION lib
++		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ 		RUNTIME DESTINATION bin
+ 	)
+ 

--- a/meta-rdk-mtk-bpir4/recipes-devtools/libubox/libubox_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-devtools/libubox/libubox_git.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:remove:scarthgap = "\
+    file://0001-version-libraries.patch \
+    file://fix-libdir.patch \
+"
+SRC_URI:append:scarthgap = "file://0001-version-libraries-fix-libdir-scarthgap-updated.patch"

--- a/wic/sdimage-Bananapi.wks
+++ b/wic/sdimage-Bananapi.wks
@@ -3,9 +3,9 @@
 
 bootloader --ptable gpt --timeout=0
 
-part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2.img" --part-name bl2 --align 17 --fixed-size 4079K --active --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_bl2_6-6.img" --part-name bl2 --align 17 --fixed-size 4079K --active --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
-part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip.bin" --part-name fip --align 6656 --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part --source rawcopy --sourceparams="file=atf/bpi-r4_sdmmc_fip_6-6.bin" --part-name fip --align 6656 --fixed-size 2M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 
 part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 8704 --fixed-size 100M --part-type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
 


### PR DESCRIPTION
Reason for Change: Addressing FUZZ patch error for libubox
Test Procedure: bitbake libubox
Risks: Low