### PR TITLE
RDKBACCL-1218: BPI Build error in latest extender build

### DIFF
--- a/conf/machine/bananapi4-rdk-broadband-ap-extender.conf
+++ b/conf/machine/bananapi4-rdk-broadband-ap-extender.conf
@@ -17,7 +17,7 @@ MACHINEOVERRIDES .="${@bb.utils.contains('DISTRO_FEATURES','sdmmc',':sd','',d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES','sdmmc','wic.bz2 ext4','',d)}"
 KERNEL_DEVICETREE_mt7988_bpi4_sd = "${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','mediatek/mt7988a-bananapi-bpi-r4.dtb','mediatek/mt7988a-bananapi-bpi-r4-sd.dtb', d)}"
 
-WKS_FILE = " ${@bb.utils.contains('DISTRO_FEATURES','EasyMesh',' sdimage-EM-Bananapi.wks',' sdimage-Bananapi.wks',d)}"
+WKS_FILE = "${@bb.utils.contains('DISTRO_FEATURES', 'kernel6-6', 'sdimage-EM-Bananapi_6-6.wks','sdimage-EM-Bananapi.wks', d)}"
 IMAGE_BOOT_FILES = "${@bb.utils.contains('DISTRO_FEATURES','sdmmc', bb.utils.contains('DISTRO_FEATURES','kernel6-6','mt7988a-bananapi-bpi-r4.dtb ${KERNEL_IMAGETYPE}','mt7988a-bananapi-bpi-r4-sd.dtb ${KERNEL_IMAGETYPE}', d),'',d)}"
 do_image_wic[recrdeps] = "do_build"
 #SDCARD supported Pre build bootloader


### PR DESCRIPTION
Reason for change: Build failure due to wks is pointing to 5.4 kernel config.
Test Procedure: Build should success with 6.6 kernel sdmmc bin and fip.
Risks: Low