### PR TITLE
RDKBACCL-1210 : Addressing build issues in meta-cmf-bananapi layer

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-support/ecryptfs-utils/ecryptfs-utils_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-support/ecryptfs-utils/ecryptfs-utils_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:append:scarthgap = " file://typedef_error_scarthgap.patch"

--- a/meta-rdk-mtk-bpir4/recipes-support/ecryptfs-utils/files/typedef_error_scarthgap.patch
+++ b/meta-rdk-mtk-bpir4/recipes-support/ecryptfs-utils/files/typedef_error_scarthgap.patch
@@ -1,0 +1,41 @@
+diff -Naur ecryptfs-utils-106-origin/src/key_mod/ecryptfs_key_mod_openssl.c ecryptfs-utils-106/src/key_mod/ecryptfs_key_mod_openssl.c
+--- ecryptfs-utils-106-origin/src/key_mod/ecryptfs_key_mod_openssl.c	2025-11-03 08:43:26.832537641 +0000
++++ ecryptfs-utils-106/src/key_mod/ecryptfs_key_mod_openssl.c	2025-11-03 08:47:12.410605053 +0000
+@@ -145,6 +145,8 @@
+ 	unsigned char *hash;
+ 	unsigned char *data = NULL;
+ 	int rc = 0;
++	const BIGNUM *n = NULL;
++	const BIGNUM *e = NULL;
+ 
+ 	hash = malloc(SHA_DIGEST_LENGTH);
+ 	if (!hash) {
+@@ -152,11 +154,12 @@
+ 		rc = -ENOMEM;
+ 		goto out;
+ 	}
+-	nbits = BN_num_bits(key->n);
++	RSA_get0_key(key, &n, &e, NULL);
++	nbits = BN_num_bits(n);
+ 	nbytes = nbits / 8;
+ 	if (nbits % 8)
+ 		nbytes++;
+-	ebits = BN_num_bits(key->e);
++	ebits = BN_num_bits(e);
+ 	ebytes = ebits / 8;
+ 	if (ebits % 8)
+ 		ebytes++;
+@@ -179,11 +182,11 @@
+ 	data[i++] = '\02';
+ 	data[i++] = (nbits >> 8);
+ 	data[i++] = nbits;
+-	BN_bn2bin(key->n, &(data[i]));
++	BN_bn2bin(n, &(data[i]));
+ 	i += nbytes;
+ 	data[i++] = (ebits >> 8);
+ 	data[i++] = ebits;
+-	BN_bn2bin(key->e, &(data[i]));
++	BN_bn2bin(e, &(data[i]));
+ 	i += ebytes;
+ 	SHA1(data, len + 3, hash);
+ 	to_hex(sig, (char *)hash, ECRYPTFS_SIG_SIZE);


### PR DESCRIPTION
Reason for change : addressing incomplete typedef for ecryptfs-utils
Test Procedure : bitbake ecryptfs-utils should not throw incomplete typedef
Risks: None