### PR TITLE
RDKB-61540: fixed disassoc after assoc retry

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/fixed_disassoc_after_assoc_retry.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/fixed_disassoc_after_assoc_retry.patch
@@ -1,0 +1,32 @@
+##########################################
+Date: Nov 6, 2025 1:00 PM
+From: 
+Subject: Fixed disassoc after multiple assoc requests
+Source: Comcast
+Upstream-Status:
+Signed-off-by: Bogdan Bogush <bogdan_bogush@comcast.com>
+##########################################
+diff --git a/source/hostap-2.11/src/ap/ieee802_11.c b/source/hostap-2.11/src/ap/ieee802_11.c
+index e3cd9e47c..2d9fbfe35 100644
+--- a/source/hostap-2.11/src/ap/ieee802_11.c
++++ b/source/hostap-2.11/src/ap/ieee802_11.c
+@@ -4923,6 +4923,19 @@ static int add_associated_sta(struct hostapd_data *hapd,
+ 		   wpa_auth_sta_ft_tk_already_set(sta->wpa_sm),
+ 		   wpa_auth_sta_fils_tk_already_set(sta->wpa_sm));
+ 
++	/* If association request retry handled after reply has already
++	 * been sent then added_unassoc is set to 0. This causes the STA to be
++	 * removed and disassociated.
++	 */
++#ifdef RDK_ONEWIFI
++	if (!mld_link_sta && !sta->added_unassoc &&
++	    !(sta->flags & WLAN_STA_AUTHORIZED)) {
++		wpa_printf(MSG_DEBUG, "%s:%d Ignore duplicated assoc request from "
++			MACSTR, __func__, __LINE__, MAC2STR(sta->addr));
++		return 0;
++	}
++#endif /* RDK_ONEWIFI */
++
+ 	if (!mld_link_sta && !sta->added_unassoc &&
+ 	    (!(sta->flags & WLAN_STA_AUTHORIZED) ||
+ 	     (reassoc && sta->ft_over_ds && sta->auth_alg == WLAN_AUTH_FT) ||

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap_2.11.bb
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap_2.11.bb
@@ -67,6 +67,7 @@ SRC_URI += " \
     file://2.11/supplicant_new.patch \
     file://2.11/bpi.patch \
     file://2.11/mlo_fix.patch \
+    file://2.11/fixed_disassoc_after_assoc_retry.patch \
     "
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DCONFIG_SME -DCONFIG_GAS -DCONFIG_AP "


### PR DESCRIPTION
Reason for change:
  Client cannot connect due to disassoc from AP.
  Scenario:
  - client sends two assoc requests
  - while second assoc request is in queue hostapd sends reply
  - when second assoc request is handled, hostapd removes STA and adds again
  - remove of STA triggers DEL_STATION event
  - DEL_STATION event sends disassoc
  - after two disassoc STA gives up and connects to different band 
  The fix is to skip remove-add STA for duplicated requests. 

Test Procedure:
  - Connect Intel BE200 client
  - Check connection successful if client retries assoc request 

Risks: Low
Priority: P1