### PR TITLE
RDKBACCL-1244 : Observing build issues in recent builds

### DIFF
--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -60,25 +60,6 @@ sed -i '203 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia.bbappen
 touch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/util/utopia_changes_applied
 fi
 
-if [ "X$KERNEL_TYPE" != "Xkernel6-6" ]; then
-    if [ ! -e ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdkwifihal_changes_applied ]; then
-         sed -i '9 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
-         sed -i '10 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
-         sed -i '11 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
-         sed -i '12 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
-         sed -i '13 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
-         sed -i '14 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
-         sed -i '15 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
-         sed -i '16 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
-         sed -i '17 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend
-         touch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/hal/rdkwifihal_changes_applied
-    fi
-    if [ ! -e ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/ccsp/onewifi_changes_applied ]; then
-         sed -i 's/^SRC_URI +=/SRC_URI_append =/' ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
-         touch ${_TOPDIR}/meta-cmf-filogic/recipes-ccsp/ccsp/onewifi_changes_applied
-    fi
-fi
-
 # commenting removing dbus.service from meta-cmf-filogic
 if [ ! -e ${_TOPDIR}/meta-cmf-filogic/recipes-core/dbus/dbus_change ]; then
 sed -i '19 s/^/#/' ${_TOPDIR}/meta-cmf-filogic/recipes-core/dbus/dbus_%.bbappend


### PR DESCRIPTION
Reason for change:  Addressed below errors and this is not needed in MP 4.2 release
23:47:02 sed: can't read /home/jenkins/jenkinsroot/workspace/build-bpi-r4-broadband-nosrc/EXEC_0/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend: No such file or directory 23:47:02 sed: can't read /home/jenkins/jenkinsroot/workspace/build-bpi-r4-broadband-nosrc/EXEC_0/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend: No such file or directory 23:47:02 sed: can't read /home/jenkins/jenkinsroot/workspace/build-bpi-r4-broadband-nosrc/EXEC_0/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend: No such file or directory 23:47:02 sed: can't read /home/jenkins/jenkinsroot/workspace/build-bpi-r4-broadband-nosrc/EXEC_0/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend: No such file or directory 23:47:02 sed: can't read /home/jenkins/jenkinsroot/workspace/build-bpi-r4-broadband-nosrc/EXEC_0/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend: No such file or directory 23:47:02 sed: can't read /home/jenkins/jenkinsroot/workspace/build-bpi-r4-broadband-nosrc/EXEC_0/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend: No such file or directory 23:47:02 sed: can't read /home/jenkins/jenkinsroot/workspace/build-bpi-r4-broadband-nosrc/EXEC_0/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend: No such file or directory 23:47:02 sed: can't read /home/jenkins/jenkinsroot/workspace/build-bpi-r4-broadband-nosrc/EXEC_0/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend: No such file or directory 23:47:02 sed: can't read /home/jenkins/jenkinsroot/workspace/build-bpi-r4-broadband-nosrc/EXEC_0/meta-cmf-filogic/recipes-ccsp/hal/rdk-wifi-hal.bbappend: No such file or directory 23:47:02 sed: can't read /home/jenkins/jenkinsroot/workspace/build-bpi-r4-broadband-nosrc/EXEC_0/meta-cmf-filogic/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend: No such file or directory 
Test Procedure: Errors not seen
Risks: Low