### PR TITLE
RDKBACCL-1034: Recreate lighttpd patch in OSS layer, remove not requi…

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-common/lighttpd/lighttpd_1.4.53.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-common/lighttpd/lighttpd_1.4.53.bbappend
@@ -1,3 +1,0 @@
-#SRC_URI:remove:broadband += " file://lighttpd_jst.conf_broadband "
-#SRC_URI:remove:broadband += " file://lighttpd_php.conf_broadband "
-

--- a/meta-rdk-mtk-bpir4/recipes-common/lighttpd/lighttpd_1.4.74.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-common/lighttpd/lighttpd_1.4.74.bbappend
@@ -1,0 +1,1 @@
+SRC_URI:remove:scarthgap += " file://0001-Force-UTC-for-lighttpd-log-messages.patch "


### PR DESCRIPTION
Manages lighttpd patch in scarthgap
0001-Force-UTC-for-lighttpd-log-messages.patch  -> removed in BPI layer, not required for 1.4.74
drop_root_lighttpd.patch -> recreated in OSS layer