### PR TITLE
RDKBACCL-1249: Observing build issues in latest wifiagent builds(Nov 12)

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/0002-Add-EHT-support.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/0002-Add-EHT-support.patch
@@ -1,17 +1,17 @@
 SOURCE:mediatek
 
 diff --git a/include/wifi_hal_generic.h b/include/wifi_hal_generic.h
-index b81ad05..2a6f33e 100644
+index 20e2628..478cdf8 100644
 --- a/include/wifi_hal_generic.h
 +++ b/include/wifi_hal_generic.h
-@@ -328,7 +328,9 @@ typedef enum{
-     WIFI_CHANNELBANDWIDTH_80MHZ = 0x4,
-     WIFI_CHANNELBANDWIDTH_160MHZ = 0x8,
-     WIFI_CHANNELBANDWIDTH_80_80MHZ = 0x10,
--    WIFI_CHANNELBANDWIDTH_320MHZ = 0x20
-+    WIFI_CHANNELBANDWIDTH_320MHZ = 0x20,
+@@ -327,7 +327,9 @@ typedef enum
+     WIFI_CHANNELBANDWIDTH_80MHZ = 0x4, /**< 80MHz. */
+     WIFI_CHANNELBANDWIDTH_160MHZ = 0x8, /**< 160MHz. */
+     WIFI_CHANNELBANDWIDTH_80_80MHZ = 0x10, /**< 80+80MHz. */
+-    WIFI_CHANNELBANDWIDTH_320MHZ = 0x20 /**< 320MHz. */
++    WIFI_CHANNELBANDWIDTH_320MHZ = 0x20, /**< 320MHz. */
 +    WIFI_CHANNELBANDWIDTH_320_1MHZ = 0x40,
 +    WIFI_CHANNELBANDWIDTH_320_2MHZ = 0x80
  } wifi_channelBandwidth_t;
- 
+
  /**

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/sta-network-wifiagent.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/sta-network-wifiagent.patch
@@ -9,14 +9,13 @@ Change-Id: Idaae3038a352e94d1f2810a8d73b7f77c8e47309
  1 file changed, 91 insertions(+)
 
 diff --git a/include/wifi_hal.h b/include/wifi_hal.h
-index 579418e..d284af4 100644
+index 7906f42..e11084f 100644
 --- a/include/wifi_hal.h
 +++ b/include/wifi_hal.h
-@@ -110,4 +110,95 @@
+@@ -117,5 +117,93 @@
  * APIs to be deprecated. Not add new function or structure!
  */
  #include "wifi_hal_deprecated.h"
-+
 +/* DRAFT FOR CLIENT API */
 +
 +
@@ -105,9 +104,6 @@ index 579418e..d284af4 100644
 +INT wifi_getApChannel(INT radioIndex,ULONG *output_ulong);   //RDKB
 +
 +INT wifi_setApChannel(INT radioIndex, ULONG channel);        //RDKB  //AP only
-+
-+
+
  #endif
--- 
-2.28.0
 

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -99,6 +99,7 @@ if [ "X$KERNEL_TYPE" == "Xkernel6-6" ]; then
     mv  ${_TOPDIR}/meta-filogic/recipes-wifi/hostapd/files/kernel6-6-patches/patches.inc ${_TOPDIR}/meta-filogic/recipes-wifi/hostapd/files/kernel6-6-patches/patches.inc_updated
     cp ${_TOPDIR}/meta-filogic/recipes-wifi/hostapd/files/kernel6-6-patches/* ${_TOPDIR}/meta-cmf-bananapi/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/kernel_6_6
     rm ${_TOPDIR}/meta-cmf-bananapi/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/kernel_6_6/patches.inc_updated
+    mv  ${_TOPDIR}/meta-filogic/recipes-wifi/hostapd/files/kernel6-6-patches/patches.inc_updated ${_TOPDIR}/meta-filogic/recipes-wifi/hostapd/files/kernel6-6-patches/patches.inc
     touch ${_TOPDIR}/meta-filogic/recipes-wifi/hostapd/kernel_6_6_patches_copied
     fi
 fi


### PR DESCRIPTION
Reason for Change: Re-generated patches
Test Procedure: rdk-wifi-halif and hostapd should compile successfully and build should be successful
Risks: Low