### PR TITLE
RDKBACCL-1237 : do_rootfs issue is seen for rdk-generic-broadband-image

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -47,4 +47,4 @@ FILES:${PN} += " \
     /usr/bin/wifi_events_consumer \
     /nvram/wifi_defaults.txt \
 "
-INSANE_SKIP:${PN} += "file-rdeps"
+RDEPENDS:${PN} += "msgpack-c"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
@@ -1,2 +1,2 @@
 include ccsp_common_bananapi.inc
-INSANE_SKIP:${PN} += "file-rdeps"
+RDEPENDS:${PN} += " msgpack-c"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/onewifi_undefine_global.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/onewifi_undefine_global.patch
@@ -1,0 +1,13 @@
+diff --git git/source/hostap-2.11/src/ap/hostapd.c git/source/hostap-2.11/src/ap/hostapd.c
+index a05de030d..9ae1032c5 100644
+--- git/source/hostap-2.11/src/ap/hostapd.c
++++ git/source/hostap-2.11/src/ap/hostapd.c
+@@ -73,7 +73,7 @@ static void hostapd_switch_color_timeout_handler(void *eloop_data,
+ 						 void *user_ctx);
+ #endif /* CONFIG_IEEE80211AX */
+ 
+-
++struct hapd_global global;
+ int hostapd_for_each_interface(struct hapd_interfaces *interfaces,
+ 			       int (*cb)(struct hostapd_iface *iface,
+ 					 void *ctx), void *ctx)

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/rdk-wifi-libhostap.bbappend
@@ -9,6 +9,7 @@ SRC_URI:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_10', 'file
 SRC_URI:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'file://2.11/Bpi_rdkwifilibhostap_2_11_changes.patch', 'file://2.10/Bpi_rdkwifilibhostap_2_10_changes.patch', d)}"
 SRC_URI:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'file://2.11/supplicant.patch', '', d)}"
 SRC_URI:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'HOSTAPD_2_11', 'file://2.11/libhostap.mk', '', d)}"
+SRC_URI:append:scarthgap = " file://2.11/onewifi_undefine_global.patch"
 
 CFLAGS:append = " -D_PLATFORM_BANANAPI_R4_ -DCONFIG_SME -DCONFIG_GAS -DCONFIG_AP "
 

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -21,12 +21,8 @@ add_busybox_fixes() {
 			cd -
                 fi
 }
-python __anonymous () {
-    if "sd" in d.getVar('MACHINEOVERRIDES', True):
-        d.setVar('do_filogic_gen_image', 'do_filogic_gen_image_sdcard')
-}
 
-do_filogic_gen_image_sdcard(){
+do_filogic_gen_image(){
        SQUASHFS_FILE_PATH="${SQUASHFS_FILE_PATH}"  # ensure exported
         if [ -z "$SQUASHFS_FILE_PATH" ]; then
         # fallback: check both possibilities

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -21,17 +21,36 @@ add_busybox_fixes() {
 			cd -
                 fi
 }
+python __anonymous () {
+    if "sd" in d.getVar('MACHINEOVERRIDES', True):
+        d.setVar('do_filogic_gen_image', 'do_filogic_gen_image_sdcard')
+}
 
-do_filogic_gen_image(){
+do_filogic_gen_image_sdcard(){
+       SQUASHFS_FILE_PATH="${SQUASHFS_FILE_PATH}"  # ensure exported
+        if [ -z "$SQUASHFS_FILE_PATH" ]; then
+        # fallback: check both possibilities
+                if [ -f "${IMGDEPLOYDIR}/${PN}-${MACHINE}.bin.squashfs-xz" ]; then
+                         SQUASHFS_FILE_PATH="${IMGDEPLOYDIR}/${PN}-${MACHINE}.bin.squashfs-xz"
+                elif [ -f "${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz" ]; then
+                         SQUASHFS_FILE_PATH="${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz"
+                else
+                         echo "ERROR: no squashfs file found"
+                         exit 1
+                fi
+        fi
         if ${@bb.utils.contains('DISTRO_FEATURES','kernel_in_ubi','true','false',d)}; then
         # create sysupgrade image align to openwrt
+                # Use dynamically detected squashfs path
+                SQUASHFS_FILE="${IMGDEPLOYDIR}/$(basename ${SQUASHFS_FILE_PATH})"
                 rm -rf ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}
                 rm -rf ${IMGDEPLOYDIR}/${PN}-${MACHINE}-sysupgrade.bin
 
                 mkdir ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}
 
                 cp ${DEPLOY_DIR_IMAGE}/fitImage ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/kernel
-                cp ${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/root
+                #cp ${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/root
+                cp ${SQUASHFS_FILE} ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/root
                 if ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','true','false',d)}; then
                 fit-rootfs-hash-tool ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/kernel ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}/root
                 fi
@@ -46,7 +65,8 @@ do_filogic_gen_image(){
                 mkdir ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb
 
                 cp ${DEPLOY_DIR_IMAGE}/fitImage-sb ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/kernel
-                cp ${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/root
+                #cp ${IMGDEPLOYDIR}/${PN}-${MACHINE}.squashfs-xz ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/root
+                cp ${SQUASHFS_FILE} ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/root
                 if ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','true','false',d)}; then
                 fit-rootfs-hash-tool ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/kernel ${IMGDEPLOYDIR}/sysupgrade-${PN}-${MACHINE}-sb/root
                 fi
@@ -57,5 +77,6 @@ do_filogic_gen_image(){
         fi
     fi
 }
+
 IMAGE_INSTALL:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ppp-enabled', '', 'pptp-linux rp-pppoe xl2tpd', d)}"
 IMAGE_INSTALL:append = "${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh',' unified-wifi-mesh unified-wifi-mesh-cli','',d)}"

--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-filogic-mt76.bbappend
@@ -4,4 +4,4 @@ RDEPENDS:packagegroup-filogic-mt76:remove:onewifi = " \
                     wifi-test-tool \
                     vts \
 "
-RDEPENDS_packagegroup-filogic-mt76:remove:broadband = " mt76-test"
+RDEPENDS:packagegroup-filogic-mt76:remove:broadband = " mt76-test"

--- a/meta-rdk-mtk-bpir4/recipes-wifi/aten/atenl.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-wifi/aten/atenl.bbappend
@@ -1,0 +1,1 @@
+INSANE_SKIP:${PN}:scarthgap += "file-rdeps"

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -75,16 +75,14 @@ if [ "X$BPI_IMG_TYPE" == "Xnand" ]; then
     sed -i '/sdmmc/s/^/#/' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
 else # SD card image is default
     mkdir -p ${_TOPDIR}/downloads
-    if [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_bl2.img ] && [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_fip.bin ]; then
-        echo "Both bl2 and fip binaries are present in local workspace."
+    if [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_bl2_6-6.img ] && [ -f ${_TOPDIR}/downloads/bpi-r4_sdmmc_fip_6-6.bin ]; then
+	    echo "Both bl2 and fip binaries are present in local workspace for 6.6 kernel."
     else
-        echo "**********************************************************************"
-        echo "> CAUTION: YOU ARE TRYING TO BUILD SD CARD IMAGE WITHOUT BL2 AND FIP BINARIES."
-        echo "> Please download the binaries from https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2025.01/bpi-r4_sdmmc_bl2.img and https://artifactory.rdkcentral.com/artifactory/RDKB-Platform/BPI-R4/uboot-2025.01/bpi-r4_sdmmc_fip.bin"
-        echo "> If you don't have access to above resources, please follow instruction in https://wiki.rdkcentral.com/pages/viewpage.action?pageId=354648448#SDMonoliticimagebuildandflashingstepsforBPIR4.-Buildingbl2.imgandfip.binincaseofnothavingaccesstoartifactoryrepository to build bl2 and fip binaries yourselves."
-        echo "> Place those binaries under ${_TOPDIR}/downloads/"
-        echo "> EXITING NOW."
-        echo "**********************************************************************"
-        return 1
+	    echo "**********************************************************************"
+	    echo "> Missing files are preventing the build from starting:"
+	    echo "> The BL2 and FIP binaries for kernel-6.6 aren't in the downloads directory. Copy these binaries into the directory and then restart the build. You can find instructions for creating the necessary binaries on the RDK-B Code Releases page: (https://wiki.rdkcentral.com/display/CMF/RDK-B+Code+Releases)"
+	    echo "**********************************************************************"
+	    return 1
+
     fi
 fi


### PR DESCRIPTION
Reason for change : observed do_hash_rootfs error for squashfs.xz
Test Procedure : bitbake rdk-generic-broadband-image should not throw No such file or directory: for rdk-generic-broadband-image-bananapi4-rdk-broadband.squashfs-xz
Risks: None