### PR TITLE
RDKBACCL-1273 : All ccsp logs are missed under rdklogs/logs folder

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,3 +16,4 @@ require conf/include/rdk-bpi-bbmasks.inc
 require conf/distro/include/rdk-bpi.inc
 
 LAYERSERIES_COMPAT:cmf-bananapi = " kirkstone scarthgap"
+BBFILE_PRIORITY_cmf-bananapi = "25"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -6,7 +6,7 @@ SRC_URI:append = " \
                 "
 CFLAGS_aarch64:append = " -Werror=format-truncation=1 "
 
-do_install:append_class-target() {
+do_install:append:class-target() {
    sed -i 's#${PARODUS_START_LOG_FILE}#/rdklogs/logs/dcmrfc.log#g' ${D}${systemd_unitdir}/system/rfc.service
    sed -i 's/rfc.service /RFCbase.sh /g' ${D}${systemd_unitdir}/system/rfc.service
 
@@ -63,7 +63,7 @@ TARGET_CFLAGS += " \
     -Wno-error=format-truncation \
 "
 
-SYSTEMD_SERVICE:${PN}:remove_onewifi = " ccspwifiagent.service"
+SYSTEMD_SERVICE:${PN}:remove:onewifi = " ccspwifiagent.service"
 SYSTEMD_SERVICE:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'onewifi.service', '', d)}"
 SYSTEMD_SERVICE:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'webconfig_bin', 'webconfig.service', '', d)}"
 SYSTEMD_SERVICE:${PN} += "notifyComp.service"
@@ -73,7 +73,7 @@ SYSTEMD_SERVICE:${PN} += "wan-initialized.target"
 SYSTEMD_SERVICE:${PN} += "wan-initialized.path"
 SYSTEMD_SERVICE:${PN}:remove = " utopia.service"
 
-FILES:${PN}:remove_onewifi = "${systemd_unitdir}/system/ccspwifiagent.service"
+FILES:${PN}:remove:onewifi = "${systemd_unitdir}/system/ccspwifiagent.service"
 FILES:${PN}:remove = "${systemd_unitdir}/system/utopia.service"
 FILES:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '${systemd_unitdir}/system/onewifi.service', '', d)}"
 FILES:${PN} += "\

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -6,11 +6,11 @@ SRC_URI += "file://service_bridge_bpi.sh"
 
 do_install:append() {
 
-install -d ${D}${sysconfdir}/
-install -d ${D}${sysconfdir}/utopia/
-install -d ${D}${sysconfdir}/utopia/service.d
+#install -d ${D}${sysconfdir}/
+#install -d ${D}${sysconfdir}/utopia/
+#install -d ${D}${sysconfdir}/utopia/service.d
 install -d -m 0777 ${D}/minidumps
-install -m 755 ${S}/source/scripts/init/system/utopia_init.sh ${D}${sysconfdir}/utopia/
+#install -m 755 ${S}/source/scripts/init/system/utopia_init.sh ${D}${sysconfdir}/utopia/
 DISTRO_WAN_ENABLED="${@bb.utils.contains('DISTRO_FEATURES','rdkb_wan_manager','true','false',d)}"
 if [ $DISTRO_WAN_ENABLED = 'true' ]; then
 


### PR DESCRIPTION
Reason for change : In scarthgap builds,through this utopia.bbapend scripts installed newly losing the modified content
Test Procedure : Flash the scarthgap, check /rdklogs/logs whether all log file are generated
Risks: None
