### PR TITLE
RDKBACCL-1274 : Scarthgap image is not booting up

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-kernel/linux/files/enable_sdcard_6_6.patch
+++ b/meta-rdk-mtk-bpir4/recipes-kernel/linux/files/enable_sdcard_6_6.patch
@@ -2,7 +2,17 @@ diff --git a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi b/arch/ar
 index c4455fbc..dd3bd8b1 100644
 --- a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
 +++ b/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
-@@ -75,6 +75,15 @@
+@@ -28,8 +28,7 @@
+ 
+ 	chosen {
+ 		stdout-path = &uart0;
+-		bootargs = "console=ttyS0,115200n1 loglevel=8 pci=pcie_bus_perf ubi.block=0,fit root=/dev/fit0 rootwait";
+-		rootdisk-spim-nand = <&ubi_rootfs>;
++		bootargs = "earlycon console=ttyS0,115200 root=/dev/mmcblk0p4 rootfstype=ext4 rw rootwait  debug=7";
+ 	};
+ 
+ 	memory {
+@@ -75,6 +74,15 @@
  			default-state = "off";
  		};
  	};
@@ -18,7 +28,7 @@ index c4455fbc..dd3bd8b1 100644
  };
  
  &eth {
-@@ -102,7 +111,7 @@
+@@ -102,7 +110,7 @@
  };
  
  &gsw_port0 {
@@ -27,7 +37,7 @@ index c4455fbc..dd3bd8b1 100644
  };
  
  &gsw_phy0_led0 {
-@@ -304,6 +313,20 @@
+@@ -304,6 +312,20 @@
  			function = "pwm";
  		};
  	};
@@ -48,7 +58,18 @@ index c4455fbc..dd3bd8b1 100644
  };
  
  &pwm {
-@@ -402,3 +425,18 @@
+@@ -379,6 +401,10 @@
+ 	};
+ };
+ 
++&spi_nand {
++    status = "disabled";
++};
++
+ &uart0 {
+ 	status = "okay";
+ };
+@@ -402,3 +428,18 @@
  &xphy {
  	status = "okay";
  };

--- a/meta-rdk-mtk-bpir4/recipes-kernel/linux/linux-mediatek_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-kernel/linux/linux-mediatek_%.bbappend
@@ -24,8 +24,10 @@ KERNEL_CONFIG_FRAGMENTS += " \
 do_filogic_patches:append() {
     cd ${S}
     if [ ! -e patch_applied_6_6 ]; then
-         patch -p1 < ${WORKDIR}/enable_sdcard_6_6.patch
-         touch patch_applied_6_6
+        if ${@bb.utils.contains('DISTRO_FEATURES', 'sdmmc', 'true', 'false', d)}; then
+            patch -p1 < ${WORKDIR}/enable_sdcard_6_6.patch
+            touch patch_applied_6_6
+        fi
     fi
 }
 # Ensure DTBs are built even if we're using fitImage

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -71,6 +71,11 @@ if [ "X$FEATURE_TYPE" == "XEasyMesh" ]; then
     sed -i '/sta_manager/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
 fi
 
+if [ ! -e ${_TOPDIR}/meta-filogic/recipes-kernel/linux/linux_changes_applied ]; then
+    sed -i -e '/WORKDIR}\/003-rdkb-refactor-bpi-r4-dts.patch/s/^/#/' ${_TOPDIR}/meta-filogic/recipes-kernel/linux/linux-mediatek_6.6.bb
+    touch ${_TOPDIR}/meta-filogic/recipes-kernel/linux/linux_changes_applied
+fi
+
 if [ "X$BPI_IMG_TYPE" == "Xnand" ]; then
     sed -i '/sdmmc/s/^/#/' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
 else # SD card image is default


### PR DESCRIPTION
Reason for change : in scarthgap image, kernel is trying to mount the rootfs to ubi
Test Procedure : Flash the scarthgap in different boards
Risks: None