### PR TITLE
RDKBACCL-757:Implement Fwupgrade HAL APIs for BPI

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-fwupgrade.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-fwupgrade.bbappend
@@ -1,9 +1,14 @@
 DESCRIPTION = "HAL Firmware Upgrade for BPI"
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-SRC_URI_append = " \
+SRC_URI_remove = "git://git01.mediatek.com/filogic/rdk-b/rdkb_hal;branch=master;protocol=https;name=fwupgradehal \
+           file://LICENSE;subdir=git \
+          "
+SRC_URI_append = "git://github.com/rdkcentral/rdkb-hal-bpi;branch=develop;protocol=https;name=fwupgradehal \
            file://start_cron.sh \
                 "
+LIC_FILES_CHKSUM = "file://../../LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
+SRCREV = "0c1948d6fd6598b0290a54c21265642faa8124da"
 do_install_append () {
          install -d ${D}${bindir}
         install -v -m 0755 ${WORKDIR}/start_cron.sh ${D}${bindir}/start_cron
@@ -13,4 +18,5 @@ DEPENDS_append += " cjson "
 RDEPENDS_${PN}_append = " cjson "
 CFLAGS_append = "-I${STAGING_INCDIR}/cjson "
 LDFLAGS += "-lcjson"
+S = "${WORKDIR}/git/source/fwupgrade"
 DEPENDS += " rdkb-halif-fwupgrade"


### PR DESCRIPTION
Reason For Change: Hal repo was privarte converted to public.
Test procedure: Firmware upgrade should work as expected.
Risks: Low