### PR TITLE
RDKBACCL-1316 : Addressing missing lib*.so files for scarthgap rootfs

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-lm-lite.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-lm-lite.bbappend
@@ -2,5 +2,5 @@ include ccsp_common_bananapi.inc
 
 EXTRA_OEMAKE += "LIBS='-lrbus'"
 
-FILES:${PN}-dev += "${libdir}/*.so"
+#FILES:${PN}-dev += "${libdir}/*.so"
 INSANE_SKIP:${PN} += "dev-so"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -23,5 +23,9 @@ do_install:append() {
 FILES:${PN} += " \
     ${libdir}/libwifi_bus.so.* \
 "
+FILES:${PN} += " \
+    ${libdir}/*so \
+"
+
 FILES_SOLIBSDEV = ""
-INSANE_SKIP_${PN} += "dev-so"
+INSANE_SKIP:${PN} += "dev-so"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -48,3 +48,7 @@ FILES:${PN} += " \
     /nvram/wifi_defaults.txt \
 "
 RDEPENDS:${PN} += "msgpack-c"
+FILES:${PN} += "${libdir}/*.so"
+FILES:${PN}-dev:remove = "${libdir}/*.so"
+INSANE_SKIP:${PN} += "dev-so"
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
@@ -1,3 +1,7 @@
 include ccsp_common_bananapi.inc
 
-FILES:${PN}-dev += "${libdir}/*.so"
+#FILES:${PN}-dev += "${libdir}/*.so"
+INSANE_SKIP:${PN} += "dev-so"
+
+SRC_URI:remove = "file://filogic-factoryReset.patch"
+

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -89,4 +89,7 @@ $custom_data_model_file_name=/usr/ccsp/tr069pa/custom_mapper.xml"  >> ${D}${sysc
 FILES:${PN} += " \
         /minidumps/ \
 "
-FILES:${PN}-dev += "${libdir}/*.so"
+#FILES:${PN}-dev += "${libdir}/*.so"
+FILES:${PN} += "${libdir}/*.so"
+INSANE_SKIP:${PN} += "dev-so"
+


### PR DESCRIPTION
Reason for change : To bring missed lib*so by removing under {PN}-dev for rootfs
Test Procedure : check whether rootfs have these respective files and wifi testing 
Risks: None