### PR TITLE
RDKBACCL-1063: Bridge mode functionality is not working as expected

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
@@ -298,6 +298,8 @@
   <Record name="eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.Radio.2.FactoryResetSSID" type="astr">0</Record>
   <Record name="eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.Radio.3.FactoryResetSSID" type="astr">0</Record>
   <Record name="eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.SsidUpgradeRequired" type="astr">1</Record>
+  <Record name="eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.X_RDK-CENTRAL_COM_ForceDisable" type="astr">false</Record>
+  <Record name="eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.X_RDK-CENTRAL_COM_ForceDisable_RadioStatus" type="astr">0</Record>
 
  <!-- Ethernet interfaces of BananaPi Pi -->
   <Record name="dmsb.ethagent.ethifcount" type="astr">4</Record>

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -43,6 +43,10 @@ sed -i "s/\$\$cmdiag_ifname=lan0$/\$\$cmdiag_ifname=net0/g" ${D}${sysconfdir}/ut
 sed -i 's/^$CosaNAT::port_trigger_enabled=1/$CosaNAT::port_trigger_enabled=0/' ${D}${sysconfdir}/utopia/system_defaults
 
 #Script for enabling bridge mode in BPIR4.
+#Renaming 6G interface name for WifiAgent
+if [ "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'true', 'false', d)}" == "false" ]; then
+    sed -i "s/wifi2/wifi16/g" ${WORKDIR}/service_bridge_bpi.sh
+fi
 install -m 755 ${WORKDIR}/service_bridge_bpi.sh ${D}${sysconfdir}/utopia/service.d/
 install -m 755 ${WORKDIR}/service_bridge_bpi.sh ${D}${sysconfdir}/utopia/service.d/service_bridge.sh
 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/service_bridge_bpi.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/service_bridge_bpi.sh
@@ -614,9 +614,11 @@ del_from_group()
 
   if [ $wifi_wifi0 == "1" ] ; then
         brctl addif "$bridge_name" wifi0
-  elif [ $wifi_wifi1 == "1" ]; then
+  fi
+  if [ $wifi_wifi1 == "1" ]; then
         brctl addif "$bridge_name" wifi1
-  elif [ $wifi_wifi2 == "1" ]; then
+  fi
+  if [ $wifi_wifi2 == "1" ]; then
         brctl addif "$bridge_name" wifi2
   fi
 


### PR DESCRIPTION
Reason for Change: 5G/6G interface was not added/removed correctly in bridge mode (brctl show)
Test Procedure: Verify 5G/6G interface is added/removed properly in brctl show during mode changes
Risks: Low