### PR TITLE
RDKBACCL-1270: Update SRCREV

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "6f69f94f176226f1c4680308d61de1b4c5743d87"
+SRCREV_rdk-wifi-hal = "5622994141f083bd1d4db18c8a58444e389a3368"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY -DCONFIG_HW_CAPABILITIES "
 


### PR DESCRIPTION
    Reason for change:
        Appending last six characters of the serial number to the BPI SSIDs.
    Test Procedure:
        Verify that last characters of the serial number appended to the SSIDs or not.
    Risks: None

    Signed-off-by: Prabhudas Gannavarapu <prabhudas_gannavarapu@comcast.com>RDKBACCL-1270: support unique ssid for each banana pi device