### PR TITLE
RDKBACCL-1336 : Updated srcrev

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "cb6eb20ce4672c9456d324e3f0114eb22eafce3f"
+SRCREV_rdk-wifi-hal = "6f8b6d653894564075b0b9f86afae210319c49fd"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY -DCONFIG_HW_CAPABILITIES "
 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-util"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-util"
-SRCREV_rdk-wifi-util = "cb6eb20ce4672c9456d324e3f0114eb22eafce3f"
+SRCREV_rdk-wifi-util = "6f8b6d653894564075b0b9f86afae210319c49fd"


### PR DESCRIPTION
Reason for change: Re-naming the wifi api's name to avoid the build errors,
| ../git/src/wifi_hal_nl80211.c:6612:12: error: conflicting types for 'get_nl80211_protocol_features'; have 'u32(int,  u32 *)' {aka 'unsigned int(int,  unsigned int *)'} |  6612 | static u32 get_nl80211_protocol_features(int nl_id, u32 *feat)
|       |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| In file included from ../git/src/wifi_hal_priv.h:86,
|                  from ../git/src/wifi_hal_nl80211.c:43:
| /home/jenkins/jenkinsroot/workspace/BPI-ctrl-dec10/build-bananapi4-rdk-broadband/tmp/work/cortexa53-rdk-linux/rdk-wifi-hal/6.1+gitAUTOINC+0e61c1f919-r0/recipe-sysroot/usr/include/rdk-wifi-libhostap/src/drivers/driver_nl80211.h:451:5: note: previous declaration of 'get_nl80211_protocol_features' with type 'u32(struct wpa_driver_nl80211_data *)' {aka 'unsigned int(struct wpa_driver_nl80211_data *)'}
|   451 | u32 get_nl80211_protocol_features(struct wpa_driver_nl80211_data *drv);
Also, BPI migrated to MP 4.2 release . It has 6.6 kernel and latest hostap.
Test Procedure: Able to compile rdk-wifi-hal and basic sanity also passed
Risks: Low