### PR TITLE
RDKBACCL-1348 : In scarthgap brlan0 is getting ip from bridge mode to router mode

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/service_bridge_bpi.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/service_bridge_bpi.sh
@@ -440,6 +440,7 @@ virtual_interface()
         if [ "$LAN_IP" != "$dst_ip" ]; then
                 ifconfig "$CMDIAG_IF" $dst_ip netmask "$LAN_NETMASK" up
         fi
+	sysevent set ipv4_4-status down
     else
         ifconfig "$CMDIAG_IF" down
         ifconfig l"$CMDIAG_IF" down


### PR DESCRIPTION
Reason for change: Bringing this fix into scarthgap branch
Test procedure: Checked IP for brlan0 during switch back from bridgemode
Risks: Low