### PR TITLE
RDKBACCL-1316 : Addressing missing lib*.so files for scarthgap rootfs

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-misc.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-misc.bbappend
@@ -4,4 +4,4 @@ CFLAGS_aarch64:append = "-Werror=format-truncation=1"
 
 CFLAGS += " -DDHCPV4_CLIENT_UDHCPC -DDHCPV6_CLIENT_DIBBLER -DUDHCPC_RUN_IN_BACKGROUND"
 
-FILES:${PN}-dev += "${libdir}/*.so"
+INSANE_SKIP:${PN} += "dev-so"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-xdns.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-xdns.bbappend
@@ -1,4 +1,4 @@
 include ccsp_common_bananapi.inc
 
 TARGET_CFLAGS += "-Wno-error=address"
-FILES:${PN}-dev += "${libdir}/*.so"
+INSANE_SKIP:${PN} += "dev-so"

--- a/meta-rdk-mtk-bpir4/recipes-common/telemetry/telemetry_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-common/telemetry/telemetry_git.bbappend
@@ -1,0 +1,1 @@
+FILES:${PN}-dev:remove = "${libdir}/*.so"

--- a/meta-rdk-mtk-bpir4/recipes-support/json-hal/json-hal-lib.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-support/json-hal/json-hal-lib.bbappend
@@ -1,0 +1,4 @@
+FILES_SOLIBSDEV = ""
+FILES:${PN} += "${libdir}/* \
+                ${bindir}/* "
+INSANE_SKIP:${PN} += "dev-so"


### PR DESCRIPTION
Reason for change : To bring missed lib*so by removing under {PN}-dev for rootfs
Test Procedure : check whether rootfs have these respective files and wifi testing
 Risks: None