### PR TITLE
RDKB-61540: Fix channel switching on BPI-R4

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/files/0001-Allow-to-cancel-CSA-if-requested-kernel_5_4.patch
+++ b/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/files/0001-Allow-to-cancel-CSA-if-requested-kernel_5_4.patch
@@ -1,0 +1,33 @@
+From e121522cc115d1eca7423400e0cf327b75019d43 Mon Sep 17 00:00:00 2001
+From: Brayan Milczarek <brayan_milczarek@comcast.com>
+Date: Tue, 23 Dec 2025 10:37:16 +0000
+Subject: [PATCH] Allow to cancel CSA if requested
+
+---
+ net/mac80211/cfg.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/net/mac80211/cfg.c b/net/mac80211/cfg.c
+index b0a5f87..f059eac 100644
+--- a/net/mac80211/cfg.c
++++ b/net/mac80211/cfg.c
+@@ -4148,8 +4148,14 @@ __ieee80211_channel_switch(struct wiphy *wiphy, struct net_device *dev,
+ 		return -EINVAL;
+ 
+ 	/* don't allow another channel switch if one is already active. */
+-	if (link_conf->csa_active)
+-		return -EBUSY;
++	//if (link_conf->csa_active)
++	//	return -EBUSY;
++
++        /*RDKB: Allow to cancel previous CSA if another request comes*/
++        if (link_conf->csa_active) {
++               link_conf->csa_active = false;
++               ieee80211_vif_unblock_queues_csa(sdata);
++        }
+ 
+ 	conf = wiphy_dereference(wiphy, link_conf->chanctx_conf);
+ 	if (!conf) {
+-- 
+2.44.4
+

--- a/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/files/0001-Allow-to-cancel-CSA-if-requested-kernel_6_6.patch
+++ b/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/files/0001-Allow-to-cancel-CSA-if-requested-kernel_6_6.patch
@@ -1,0 +1,41 @@
+From ea370587a77a92a322fddf76a8ff1a6a15287b1b Mon Sep 17 00:00:00 2001
+From: Brayan Milczarek <brayan_milczarek@comcast.com>
+Date: Thu, 18 Dec 2025 14:30:14 +0000
+Subject: [PATCH] Allow to cancel CSA if requested
+
+---
+ net/mac80211/cfg.c | 18 +++++++++++++-----
+ 1 file changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/net/mac80211/cfg.c b/net/mac80211/cfg.c
+index 9f5d016..9c67c71 100644
+--- a/net/mac80211/cfg.c
++++ b/net/mac80211/cfg.c
+@@ -4350,11 +4350,19 @@ __ieee80211_channel_switch(struct wiphy *wiphy, struct net_device *dev,
+ 	/* don't allow another channel switch if one is already active
+ 	 * except the case of post-CSA radar detection.
+ 	 */
+-	if (link_conf->csa_active) {
+-		if (!sdata->wdev.links[link_id].cac_started)
+-			return -EBUSY;
+-		ieee80211_dfs_cac_cancel(local, chanctx);
+-	}
++	//if (link_conf->csa_active) {
++	//	if (!sdata->wdev.links[link_id].cac_started)
++	//		return -EBUSY;
++	//	ieee80211_dfs_cac_cancel(local, chanctx);
++	//}
++	
++        /*RDKB: Allow to cancel previous CSA if another request comes*/
++        if (link_conf->csa_active) {
++               if (sdata->wdev.links[link_id].cac_started)
++                       ieee80211_dfs_cac_cancel(local, chanctx);
++               link_conf->csa_active = false;
++               ieee80211_vif_unblock_queues_csa(sdata);
++        }
+ 
+ 	ch_switch.timestamp = 0;
+ 	ch_switch.device_timestamp = 0;
+-- 
+2.44.4
+

--- a/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/linux-mac80211_6.%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/linux-mac80211_6.%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append = " ${@bb.utils.contains('DISTRO_FEATURES','kernel6-6','file://0001-Allow-to-cancel-CSA-if-requested-kernel_6_6.patch','file://0001-Allow-to-cancel-CSA-if-requested-kernel_5_4.patch', d)}" 


### PR DESCRIPTION
Reason for change: When switching the channels, for MLD AP interface we need to send NL80211_CMD_CHANNEL_SWITCH on other links in the MLD group as well. This requires at times cancelling CSA on radio.

Test Procedure: Change channel on band, check if change is reflected, check for information on partner links on other bands if applicable Risks: Low
Priority: P1