### PR TITLE
RDKB-61540: enable MLO by default

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -62,7 +62,7 @@ DISTRO_FEATURES_append = " kernel6-6"
 
 DISTRO_FEATURES_append = " CONFIG_IEEE80211BE"
 
-#DISTRO_FEATURES_append = " generic_mlo"
+DISTRO_FEATURES_append = " generic_mlo"
 
 #Enable the below DISTRO to enable Hybrid Hal(rndis/modem) for cellular devices
 #DISTRO_FEATURES_append_broadband = " cellular_hybrid_support"


### PR DESCRIPTION
Reason for change: enable MLO by default
Test Procedure: check mld0 interface available and configured
Risks: Low
Priority: P1