### PR TITLE
RDKBACCL-1352: New rdm-agent import change is not building

### DIFF
--- a/conf/distro/include/rdk-bpi-ap-extender.inc
+++ b/conf/distro/include/rdk-bpi-ap-extender.inc
@@ -34,3 +34,6 @@ DISTRO_FEATURES_append = " generic_mlo"
 
 # Kernel 6.6
 DISTRO_FEATURES_append = " kernel6-6"
+
+#Disable rdm-agent for reference platform
+#DISTRO_FEATURES_append = "RDM"

--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -66,3 +66,6 @@ DISTRO_FEATURES_append = " CONFIG_IEEE80211BE"
 
 #Enable the below DISTRO to enable Hybrid Hal(rndis/modem) for cellular devices
 #DISTRO_FEATURES_append_broadband = " cellular_hybrid_support"
+
+#Disable rdm-agent for reference platform
+#DISTRO_FEATURES_append = "RDM"


### PR DESCRIPTION
Reason for change: rdm-agent is not used in reference platform, added distro to disable it.
Test Procedure: Build should succeed and sanity should pass for reference platform.
Risks: Low