### PR TITLE
RDKBACCL-1389 : Need to define EASY_MESH_NODE flag in rdk-wifi-hal

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=libwebconfig"
 
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=libwebconfig"
-SRCREV_libwebconfig = "b32832f8062ae47535973379954d65193f4c3880"
+SRCREV_libwebconfig = "74ea1f6ca37612b13cfccba6213fe3fb06beb982"
 
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap unified-wifi-mesh-header ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-easymesh ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=OneWifi"
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=OneWifi"
-SRCREV_OneWifi = "b32832f8062ae47535973379954d65193f4c3880"
+SRCREV_OneWifi = "74ea1f6ca37612b13cfccba6213fe3fb06beb982"
 DEPENDS_append = " mesh-agent "
 DEPENDS_remove = " opensync "
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,12 +1,13 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "6f8b6d653894564075b0b9f86afae210319c49fd"
+SRCREV_rdk-wifi-hal = "783ce174a08eb37a77ba8730437eba1b665dbe06"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY -DCONFIG_HW_CAPABILITIES "
 
 CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'generic_mlo', ' -DCONFIG_GENERIC_MLO -DCONFIG_MLO ', '', d)}"
 CFLAGS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'kernel6-6' , ' -DKERNEL_6_6 ','', d)}"
+CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -DEASY_MESH_NODE  ', '', d)}"
 
 CFLAGS_append_kirkstone = " -fcommon"
 CFLAGS_remove = "-DCONFIG_MBO"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-halif.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-halif.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
   
 SRC_URI_remove_onewifi = "git://github.com/rdkcentral/rdkb-halif-wifi.git;protocol=https;branch=main"
 SRC_URI_onewifi = "git://github.com/rdkcentral/rdkb-halif-wifi.git;protocol=https;branch=develop"
-SRCREV_onewifi = "c586c6d9f1321fa4fa6bfa8e9106226fd3600312"
+SRCREV_onewifi = "708556071362e41e3cafb35d9a5b80d392bb392b"
 
 SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' ', ' file://sta-network-wifiagent.patch', d)}"
 SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' ', ' file://0002-Add-EHT-support.patch', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-util"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-util"
-SRCREV_rdk-wifi-util = "6f8b6d653894564075b0b9f86afae210319c49fd"
+SRCREV_rdk-wifi-util = "783ce174a08eb37a77ba8730437eba1b665dbe06"

--- a/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/files/1001-BPIR4_Enable_Beacon_Frame_Subscription.patch
+++ b/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/files/1001-BPIR4_Enable_Beacon_Frame_Subscription.patch
@@ -1,0 +1,12 @@
+--- backports-6.16/net/mac80211/main.c_o	2026-01-09 12:15:28.236027659 +0000
++++ backports-6.16/net/mac80211/main.c	2026-01-09 12:15:48.259921922 +0000
+@@ -680,7 +680,8 @@
+ 		 */
+ 		.rx = BIT(IEEE80211_STYPE_ACTION >> 4) |
+ 			BIT(IEEE80211_STYPE_AUTH >> 4) |
+-			BIT(IEEE80211_STYPE_PROBE_REQ >> 4),
++			BIT(IEEE80211_STYPE_PROBE_REQ >> 4) |
++			BIT(IEEE80211_STYPE_BEACON >> 4),
+ 	},
+ 	[NL80211_IFTYPE_AP] = {
+ 		.tx = 0xffff,

--- a/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/linux-mac80211_6.%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/linux-mac80211_6.%.bbappend
@@ -1,3 +1,4 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI:append = " file://1000-get-station-increase-buffer-size.patch "
+SRC_URI:append = " file://1001-BPIR4_Enable_Beacon_Frame_Subscription.patch "


### PR DESCRIPTION
Reason for change:
1) Need to define EASY_MESH_NODE flag in rdk-wifi-hal 
2) Need to update srcrev to address the build issues
3) Need to add kernel patch for Beacon frame support 
Test Procedure: Validated the EasyMesh feature
Risks: None