### PR TITLE
RDKBACCL-1439: Easymesh - Enable MLO for all private VAPs

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em.json
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em.json
@@ -23,6 +23,7 @@
                         },
                         {
                             "InterfaceName": "wifi2",
+                            "MldName": "mld0",
                             "Bridge": "brlan0",
                             "vlanId": 0,
                             "vapIndex": 16,
@@ -86,6 +87,7 @@
                         },
                         {
                             "InterfaceName": "wifi0",
+                            "MldName": "mld0",
                             "Bridge": "brlan0",
                             "vlanId": 0,
                             "vapIndex": 0,


### PR DESCRIPTION
RDKBACCL-1439: Easymesh - Enable MLO for all private VAPs

Reason for change: To enable BE mode for all private vaps in easymesh build.
Test Procedure: Ensure BE mode enabled for private vaps and client connections works in MLO.
Risks: Medium
Priority: P1