### PR TITLE
RDKBACCL-1428 : Extender onboard should be happen if we switch the same sd card to any new boards

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ext.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ext.sh
@@ -72,9 +72,6 @@ ip link set dev "mld0" address "$new_mac"
 #To update al_mac addr in EasymesgCfg.json
 al_mac_addr=`cat /nvram/EasymeshCfg.json | grep AL_MAC_ADDR  | cut -d '"' -f4`
 al_mac=`iw dev wifi1.3 info | grep addr | cut -d ' ' -f2`
-                 
-if [ "$al_mac_addr" = "00:00:00:00:00:00" ]; then
-        sed -i "s/$al_mac_addr/$al_mac/g" /nvram/EasymeshCfg.json
-fi
+sed -i "s/$al_mac_addr/$al_mac/g" /nvram/EasymeshCfg.json
 
 exit 0


### PR DESCRIPTION
Reason for change: Removed NULL check from pre script to add almac addr during every boot up
Test Procedure: Validated the EasyMesh feature
Risks: None