### PR TITLE
RDKBWIFI-202: Implementation of Traffic Separation in unified-wifi-mesh

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em.json
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em.json
@@ -9,14 +9,14 @@
                     "InterfaceList": [
                         {
                             "InterfaceName": "wifi2.2",
-                            "Bridge": "brlan0",
+                            "Bridge": "brlan2",
                             "vlanId": 0,
                             "vapIndex": 17,
                             "vapName": "iot_ssid_6g"
                         },
                         {
                             "InterfaceName": "wifi2.1",
-                            "Bridge": "brlan0",
+                            "Bridge": "brlan1",
                             "vlanId": 0,
                             "vapIndex": 22,
                             "vapName": "mesh_backhaul_6g"
@@ -44,14 +44,14 @@
                         },
                         {
                             "InterfaceName": "wifi1.2",
-                            "Bridge": "brlan0",
+                            "Bridge": "brlan2",
                             "vlanId": 0,
                             "vapIndex": 3,
                             "vapName": "iot_ssid_5g"
                         },
                         {
                             "InterfaceName": "wifi1.1",
-                            "Bridge": "brlan0",
+                            "Bridge": "brlan1",
                             "vlanId": 0,
                             "vapIndex": 13,
                             "vapName": "mesh_backhaul_5g"
@@ -73,14 +73,14 @@
                     "InterfaceList": [
                         {
                             "InterfaceName": "wifi0.2",
-                            "Bridge": "brlan0",
+                            "Bridge": "brlan2",
                             "vlanId": 0,
                             "vapIndex": 2,
                             "vapName": "iot_ssid_2g"
                         },
                         {
                             "InterfaceName": "wifi0.1",
-                            "Bridge": "brlan0",
+                            "Bridge": "brlan1",
                             "vlanId": 0,
                             "vapIndex": 12,
                             "vapName": "mesh_backhaul_2g"


### PR DESCRIPTION
Reason for change: Added traffic seperation TLV implementation
Test Procedure: Verify build is successfull and check if traffic seperation is functional
Risks: Medium
Priority: P2