### PR TITLE
RDKBACCL-1463: DB and other customized values are overwritten to default without FR after firmware upgrade

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -50,6 +50,7 @@ do_install_append_class-target() {
    install -D -m 0644 ${S}/systemd_units/notifyComp.service ${D}${systemd_unitdir}/system/notifyComp.service
    install -D -m 0644 ${S}/systemd_units/gwprovapp.service ${D}${systemd_unitdir}/system/gwprovapp.service
    sed -i "s/After=securemount.service/After=PsmSsp.service/g" ${D}${systemd_unitdir}/system/gwprovapp.service
+   sed -i "/rdklogs/ a\ExecStartPre=/bin/mkdir -p /nvram\nExecStartPre=-/bin/sh -c 'mount /dev/mmcblk0p9 /nvram'" \${D}${systemd_unitdir}/system/gwprovapp.service
    install -D -m 0644 ${WORKDIR}/gwprovapp.conf ${D}${systemd_unitdir}/system/gwprovapp.service.d/gwprovapp.conf
    rm ${D}${systemd_unitdir}/system/utopia.service
 


### PR DESCRIPTION
Reason for change: DB should not be overritten after firmware upgrade 
Test Procedure: Build should pass and functionality should work without failure 
Risks:low