### PR TITLE
RDKBACCL-1479 : Observing build error on EM Tip revision Controller & Extender builds

### DIFF
--- a/conf/distro/include/rdk-bpi-ap-extender.inc
+++ b/conf/distro/include/rdk-bpi-ap-extender.inc
@@ -23,7 +23,6 @@ DISTRO_FEATURES_append = " sdmmc"
 
 # Easymesh
 DISTRO_FEATURES_append = " EasyMesh"
-DISTRO_FEATURES_append = " sta_manager"
 DISTRO_FEATURES_append = " with_alsap" 
 
 # MLO

--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -47,7 +47,6 @@ DISTRO_FEATURES_remove = " lan0_as_wan"
 
 #Need to enable below distro once required changes are merged 
 #DISTRO_FEATURES_append = " EasyMesh"
-#DISTRO_FEATURES_append = " sta_manager"
 #DISTRO_FEATURES_append = " with_alsap"
 #DISTRO_FEATURES_append = " Em_Unittest"
 PREFERRED_VERSION_go = "1.24.%"

--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -85,7 +85,6 @@ fi
 
 if [ "X$FEATURE_TYPE" == "XEasyMesh" ]; then
     sed -i '/EasyMesh/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
-    sed -i '/sta_manager/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
     sed -i '/with_alsap/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
     sed -i '/generic_mlo/s/^#//' ${_TOPDIR}/meta-cmf-bananapi/conf/distro/include/rdk-bpi.inc
     if [ "X$EM_UNITTEST" == "Xyes" ]; then


### PR DESCRIPTION
Reason for change: Disabled sta_manager distro feature in BPI platform
Test Procedure: Build successful
Risks: None