### PR TITLE
RDKBACCL-1343: Utilizing rfcmgr for BPI

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -14,7 +14,6 @@ do_install_append_class-target() {
    sed -i "/WorkingDirectory=/a ExecStartPre\=\/bin/sh -c '\/lib/rdk/webpa_pre_setup.sh'\\;" ${D}${systemd_unitdir}/system/webpa.service
 
    sed -i 's#${PARODUS_START_LOG_FILE}#/rdklogs/logs/dcmrfc.log#g' ${D}${systemd_unitdir}/system/rfc.service
-   sed -i 's/rfc.service /RFCbase.sh /g' ${D}${systemd_unitdir}/system/rfc.service
 
    DISTRO_OneWiFi_ENABLED="${@bb.utils.contains('DISTRO_FEATURES','OneWifi','true','false',d)}"
    if [ $DISTRO_OneWiFi_ENABLED = 'true' ]; then


### PR DESCRIPTION
Reason for change:
     Adding required changes to support rfcMgr for BPI
Test Procedure:
     Verify RFC feature is working or not. Feature should work and generate dcmrfc logs.
Risks: None