### PR TITLE
RDKBWIFI-349: Easymesh - Enable MLO for all backhaul VAPs

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ctrl.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ctrl.sh
@@ -37,6 +37,7 @@ iw phy phy0 interface add wifi2 type __ap
 iw phy phy0 interface add wifi2.1 type __ap
 iw phy phy0 interface add wifi2.2 type __ap
 iw phy phy0 interface add mld0 type __ap radios all
+iw phy phy0 interface add mld1 type __ap radios all
 
 #Obtain the wifi mac address
 wifi0_mac=`cat /nvram/mac_addresses.txt | grep -a wifi0 | cut -d " " -f 2 | head -n1`
@@ -84,14 +85,24 @@ ifconfig wifi2 up
 ifconfig wifi2.1 up
 ifconfig wifi2.2 up
 
-# Set MLD interface address as wifi2 MAC address + 1
-prefix="${wifi2_mac%:*}"
-last_byte="${wifi2_mac##*:}"
+# Set MLD interface address as wifi2.2 MAC address + 1
+prefix_mld0="${wifi2_2_mac%:*}"
+last_byte_mld0="${wifi2_2_mac##*:}"
 
-new_byte=$(printf "%02X" $(( (0x$last_byte + 1) & 0xFF )))
-new_mac="$prefix:$new_byte"
+new_byte_mld0=$(printf "%02X" $(( (0x$last_byte_mld0 + 1) & 0xFF )))
+new_mac_mld0="$prefix_mld0:$new_byte_mld0"
 
 ip link set dev "mld0" down
-ip link set dev "mld0" address "$new_mac"
+ip link set dev "mld0" address "$new_mac_mld0"
+
+# Set MLD interface address as mld0 MAC address + 1
+prefix_mld1="${new_mac_mld0%:*}"
+last_byte_mld1="${new_mac_mld0##*:}"
+
+new_byte_mld1=$(printf "%02X" $(( (0x$last_byte_mld1 + 1) & 0xFF )))
+new_mac_mld1="$prefix_mld1:$new_byte_mld1"
+
+ip link set dev "mld1" down
+ip link set dev "mld1" address "$new_mac_mld1"
 
 exit 0

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ext.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ext.sh
@@ -26,6 +26,7 @@ iw phy phy0 interface add wifi2 type __ap
 iw phy phy0 interface add wifi2.1 type __ap
 iw phy phy0 interface add wifi2.2 type __ap
 iw phy phy0 interface add mld0 type __ap radios all
+iw phy phy0 interface add mld1 type __ap radios all
 
 #Obtain the wifi mac address
 wifi0_mac=`cat /nvram/mac_addresses.txt | grep -a wifi0 | cut -d " " -f 2 | head -n1`
@@ -73,15 +74,25 @@ ifconfig wifi2 up
 ifconfig wifi2.1 up
 ifconfig wifi2.2 up
 
-# Set MLD interface address as wifi2 MAC address + 1
-prefix="${wifi2_mac%:*}"
-last_byte="${wifi2_mac##*:}"
+# Set MLD interface address as wifi2.2 MAC address + 1
+prefix_mld0="${wifi2_2_mac%:*}"
+last_byte_mld0="${wifi2_2_mac##*:}"
 
-new_byte=$(printf "%02X" $(( (0x$last_byte + 1) & 0xFF )))
-new_mac="$prefix:$new_byte"
+new_byte_mld0=$(printf "%02X" $(( (0x$last_byte_mld0 + 1) & 0xFF )))
+new_mac_mld0="$prefix_mld0:$new_byte_mld0"
 
 ip link set dev "mld0" down
-ip link set dev "mld0" address "$new_mac"
+ip link set dev "mld0" address "$new_mac_mld0"
+
+# Set MLD interface address as mld0 MAC address + 1
+prefix_mld1="${new_mac_mld0%:*}"
+last_byte_mld1="${new_mac_mld0##*:}"
+
+new_byte_mld1=$(printf "%02X" $(( (0x$last_byte_mld1 + 1) & 0xFF )))
+new_mac_mld1="$prefix_mld1:$new_byte_mld1"
+
+ip link set dev "mld1" down
+ip link set dev "mld1" address "$new_mac_mld1"
 
 #To update al_mac addr in EasymesgCfg.json
 al_mac_addr=`cat /nvram/EasymeshCfg.json | grep AL_MAC_ADDR  | cut -d '"' -f4`

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap.json
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap.json
@@ -16,6 +16,7 @@
                         },
                         {
                             "InterfaceName": "wifi22",
+                            "MldName": "mld1",
                             "Bridge": "brlan2",
                             "vlanId": 0,
                             "vapIndex": 22,
@@ -72,6 +73,7 @@
                         },
                         {
                             "InterfaceName": "wifi13",
+                            "MldName": "mld1",
                             "Bridge": "brlan3",
                             "vlanId": 0,
                             "vapIndex": 13,
@@ -136,6 +138,7 @@
                         },
                         {
                             "InterfaceName": "wifi12",
+                            "MldName": "mld1",
                             "Bridge": "brlan2",
                             "vlanId": 0,
                             "vapIndex": 12,

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em.json
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/InterfaceMap_em.json
@@ -16,6 +16,7 @@
                         },
                         {
                             "InterfaceName": "wifi2.1",
+                            "MldName": "mld1",
                             "Bridge": "brlan0",
                             "vlanId": 0,
                             "vapIndex": 22,
@@ -51,6 +52,7 @@
                         },
                         {
                             "InterfaceName": "wifi1.1",
+                            "MldName": "mld1",
                             "Bridge": "brlan0",
                             "vlanId": 0,
                             "vapIndex": 13,
@@ -80,6 +82,7 @@
                         },
                         {
                             "InterfaceName": "wifi0.1",
+                            "MldName": "mld1",
                             "Bridge": "brlan0",
                             "vlanId": 0,
                             "vapIndex": 12,


### PR DESCRIPTION
RDKBWIFI-349: Easymesh - Enable MLO for all backhaul VAPs

Reason for change: Added mld1 interface for enabling backhaul MLO.
Test Procedure: Ensure BE mode enabled for backhaul vaps and extender connections works in MLO.
Risks: Medium
Priority: P1