### PR TITLE
RDKBACCL-1519 : Oberving build issues in latest tip(i,e Mar5)

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -48,4 +48,5 @@ FILES_${PN} += " \
     ${prefix}/ccsp/wifi/onewifi_pre_start.sh \
     /usr/bin/wifi_events_consumer \
     /usr/ccsp/wifi/wifi_defaults.txt \
+    /usr/lib/libwifi* \
 "


### PR DESCRIPTION
Reason for change: Below errors are seen
 QA Issue: ccsp-one-wifi: Files/directories were installed but not shipped in any package:
  /usr/lib/libwifi_quality_manager.so.0
  /usr/lib/libwifi_quality_manager.so.0.0.0
  /usr/lib/libwifi_math_utils.so.0.0.0
  /usr/lib/libwifi_math_utils.so.0
Test Procedure:Able to compile onewifi
Risks: None