### PR TITLE
RDKBACCL-1522 : observing build issue in recent builds

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -1,5 +1,6 @@
 include ccsp_common_bananapi.inc
 
+SRCREV_ccsp_common_library = "2bb388fda59494cd3cf3a9e2139aa3d7dc537edb"
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:${THISDIR}/files:"
 SRC_URI_append = " \
                    file://gwprovapp.conf \


### PR DESCRIPTION
Reason for change: updated latest tag release for ccsp-common to unblock the wan-manager compilation issue.
This is temporary fix 
Test Procedure: ABle to make build successful
Risks: Low