### PR TITLE
RDKBACCL-XXXX: 2.11 hostap related telemetry enhancement

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/kernel_5_4/xfi_tel_compete_2_11.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/kernel_5_4/xfi_tel_compete_2_11.patch
@@ -1,0 +1,202 @@
+diff --git a/source/hostap-2.11/src/ap/ap_drv_ops.c b/source/hostap-2.11/src/ap/ap_drv_ops.c
+index bc160fd49..5c6162dfb 100644
+--- a/source/hostap-2.11/src/ap/ap_drv_ops.c
++++ b/source/hostap-2.11/src/ap/ap_drv_ops.c
+@@ -962,12 +962,12 @@ int hostapd_drv_sta_deauth(struct hostapd_data *hapd,
+ 					reason, link_id);
+ }
+ 
+-int hostapd_drv_radius_eap_failure(struct hostapd_data *hapd,
++int hostapd_drv_radius_eap_failure(struct hostapd_data *hapd, const u8 *addr,
+                            int failure_reason)
+ {
+        if (!hapd->driver || !hapd->driver->radius_eap_failure || !hapd->drv_priv)
+                return 0;
+-       return hapd->driver->radius_eap_failure(hapd->drv_priv, failure_reason);
++       return hapd->driver->radius_eap_failure(hapd->drv_priv, addr, failure_reason);
+ }
+ 
+ int hostapd_drv_radius_fallback_failover(void *ctx, int radius_switch_reason)
+@@ -1366,7 +1366,12 @@ size_t hostapd_drv_eid_rnr_colocation_len(struct hostapd_data *hapd,
+ 
+ 	return hapd->driver->get_rnr_colocation_len(hapd->drv_priv, current_len);
+ }
+-
++int hostapd_drv_get_handshake_status(struct hostapd_data *hapd, const u8 *addr, int status)
++{
++	if(!hapd->driver || !hapd->driver->get_handshake_status)
++		return -1;
++	return hapd->driver->get_handshake_status(hapd->drv_priv, addr, status);
++}
+ int hostapd_drv_get_sta_auth_type(struct hostapd_data *hapd,
+ 					const u8 *addr, const u8 *ies, size_t ies_len, int frame_type)
+ {
+diff --git a/source/hostap-2.11/src/ap/ap_drv_ops.h b/source/hostap-2.11/src/ap/ap_drv_ops.h
+index e25c94bd8..6b7874c4e 100644
+--- a/source/hostap-2.11/src/ap/ap_drv_ops.h
++++ b/source/hostap-2.11/src/ap/ap_drv_ops.h
+@@ -116,7 +116,7 @@ int hostapd_drv_send_mlme(struct hostapd_data *hapd,
+ 			  int no_encrypt);
+ int hostapd_drv_sta_deauth(struct hostapd_data *hapd,
+ 			   const u8 *addr, int reason);
+-int hostapd_drv_radius_eap_failure(struct hostapd_data *hapd, int failure_reason);
++int hostapd_drv_radius_eap_failure(struct hostapd_data *hapd, const u8 *addr, int failure_reason);
+ int hostapd_drv_radius_fallback_failover(void *ctx, int radius_switch_reason);
+ int hostapd_drv_sta_notify_deauth(struct hostapd_data *hapd,
+ 			   const u8 *addr, int reason);
+@@ -211,6 +211,8 @@ int hostapd_drv_set_eml_omn(struct hostapd_data *hapd, u8 *mac, struct eml_omn_e
+ int hostapd_drv_csi_set(struct hostapd_data *hapd, u8 mode, u8 cfg, u8 v1, u32 v2, u8 *mac);
+ int hostapd_drv_csi_dump(struct hostapd_data *hapd, void *dump_buf);
+ 
++int hostapd_drv_get_handshake_status(struct hostapd_data *hapd, const u8 *addr, int status);
++
+ #include "drivers/driver.h"
+ 
+ int hostapd_drv_wnm_oper(struct hostapd_data *hapd,
+diff --git a/source/hostap-2.11/src/ap/ieee802_1x.c b/source/hostap-2.11/src/ap/ieee802_1x.c
+index c8aeaa219..7183aa482 100644
+--- a/source/hostap-2.11/src/ap/ieee802_1x.c
++++ b/source/hostap-2.11/src/ap/ieee802_1x.c
+@@ -1697,10 +1697,11 @@ static void ieee802_1x_decapsulate_radius(struct hostapd_data *hapd,
+ 		break;
+ 	case EAP_CODE_SUCCESS:
+ 		os_strlcpy(buf, "EAP Success", sizeof(buf));
++                hostapd_drv_radius_eap_failure(hapd, sm->addr, DRV_EAP_SUCCESS);
+ 		break;
+ 	case EAP_CODE_FAILURE:
+ 		os_strlcpy(buf, "EAP Failure", sizeof(buf));
+-		hostapd_drv_radius_eap_failure(hapd, DRV_EAP_FAILURE);
++                hostapd_drv_radius_eap_failure(hapd, sm->addr, DRV_EAP_FAILURE);
+ 		break;
+ 	default:
+ 		os_strlcpy(buf, "unknown EAP code", sizeof(buf));
+@@ -2276,6 +2277,7 @@ ieee802_1x_receive_auth(struct radius_msg *msg, struct radius_msg *req,
+ 		if ((hapd->conf->rdk_greylist  || hapd->conf->connected_building_avp) && !hapd->conf->ieee802_1x)
+ 			ieee802_1x_set_sta_authorized(hapd, sta, 1);
+ #endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
++                hostapd_drv_radius_eap_failure(hapd, sm->addr, DRV_RADIUS_ACCESS_ACCEPT);
+ 		break;
+ 	case RADIUS_CODE_ACCESS_REJECT:
+ 		sm->eap_if->aaaFail = true;
+@@ -2318,7 +2320,7 @@ ieee802_1x_receive_auth(struct radius_msg *msg, struct radius_msg *req,
+ 			}
+ 		}
+ #endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+-		hostapd_drv_radius_eap_failure(hapd, DRV_RADIUS_ACCESS_REJECT);
++                hostapd_drv_radius_eap_failure(hapd, sm->addr, DRV_RADIUS_ACCESS_REJECT);
+ 		break;
+ 	case RADIUS_CODE_ACCESS_CHALLENGE:
+ 		sm->eap_if->aaaEapReq = true;
+diff --git a/source/hostap-2.11/src/ap/ieee802_1x.h b/source/hostap-2.11/src/ap/ieee802_1x.h
+index 43e75e004..5ddca6460 100644
+--- a/source/hostap-2.11/src/ap/ieee802_1x.h
++++ b/source/hostap-2.11/src/ap/ieee802_1x.h
+@@ -9,8 +9,10 @@
+ #ifndef IEEE802_1X_H
+ #define IEEE802_1X_H
+ 
++#define DRV_RADIUS_ACCESS_ACCEPT 0
+ #define DRV_RADIUS_ACCESS_REJECT 1
+ #define DRV_EAP_FAILURE 2
++#define DRV_EAP_SUCCESS 3
+ 
+ struct hostapd_data;
+ struct sta_info;
+diff --git a/source/hostap-2.11/src/ap/wpa_auth.c b/source/hostap-2.11/src/ap/wpa_auth.c
+index f32bc2d78..52b0d43d6 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth.c
++++ b/source/hostap-2.11/src/ap/wpa_auth.c
+@@ -41,7 +41,7 @@
+ #define STATE_MACHINE_DATA struct wpa_state_machine
+ #define STATE_MACHINE_DEBUG_PREFIX "WPA"
+ #define STATE_MACHINE_ADDR wpa_auth_get_spa(sm)
+-
++#define EAPOL_HS_SUCCESS 1
+ 
+ static void wpa_send_eapol_timeout(void *eloop_ctx, void *timeout_ctx);
+ static int wpa_sm_step(struct wpa_state_machine *sm);
+@@ -302,6 +302,13 @@ static inline int wpa_auth_set_key(struct wpa_authenticator *wpa_auth,
+ 				     key, key_len, key_flag);
+ }
+ 
++static void wpa_get_handshake_status(struct wpa_authenticator *wpa_auth, const u8 *addr, int status)
++{
++	if(!wpa_auth->cb->get_handshake_status)
++		return;
++	wpa_auth->cb->get_handshake_status(wpa_auth->cb_ctx, addr, status);
++}
++
+ static void wpa_auth_get_sta_auth_type(struct wpa_authenticator *wpa_auth, const u8 *addr,
+ 					const u8 *data, size_t data_len, int frame_type)
+ {
+@@ -5262,6 +5269,7 @@ SM_STATE(WPA_PTK, PTKINITDONE)
+ 			 sm->wpa == WPA_VERSION_WPA ? "WPA" : "RSN");
+ 	wpa_msg(sm->wpa_auth->conf.msg_ctx, MSG_INFO, "EAPOL-4WAY-HS-COMPLETED "
+ 		MACSTR, MAC2STR(sm->addr));
++	wpa_get_handshake_status(sm->wpa_auth, sm->addr, EAPOL_HS_SUCCESS);
+ 
+ #ifdef CONFIG_IEEE80211R_AP
+ 	wpa_ft_push_pmk_r1(sm->wpa_auth, wpa_auth_get_spa(sm));
+diff --git a/source/hostap-2.11/src/ap/wpa_auth.h b/source/hostap-2.11/src/ap/wpa_auth.h
+index 4840c0c6f..c9dfd7bfa 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth.h
++++ b/source/hostap-2.11/src/ap/wpa_auth.h
+@@ -436,6 +436,7 @@ void (*get_sta_auth_type)(void *ctx, const u8 *addr,const u8 *ies, size_t ies_le
+ 			       bool rekey);
+ #endif /* CONFIG_IEEE80211BE */
+ 	int (*get_drv_flags)(void *ctx, u64 *drv_flags, u64 *drv_flags2);
++	void (*get_handshake_status)(void *ctx, const u8 *addr, int status);
+ };
+ 
+ struct wpa_authenticator * wpa_init(const u8 *addr,
+diff --git a/source/hostap-2.11/src/ap/wpa_auth_glue.c b/source/hostap-2.11/src/ap/wpa_auth_glue.c
+index ab99fd400..95d98f894 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth_glue.c
++++ b/source/hostap-2.11/src/ap/wpa_auth_glue.c
+@@ -1670,6 +1670,17 @@ static void hostapd_request_radius_psk(void *ctx, const u8 *addr, int key_mgmt,
+ }
+ #endif /* CONFIG_NO_RADIUS */
+ 
++static void hostapd_wpa_get_handshake_status(void *ctx, const u8 *addr, int status)
++{
++	struct hostapd_data *hapd = ctx;
++
++	if(!hapd){
++		wpa_printf(MSG_ERROR, "%s hapd is NULL", __func__);
++		return;
++	}
++	hostapd_drv_get_handshake_status(hapd, addr, status);
++}
++
+ static void hostapd_wpa_auth_get_sta_auth_type(void *ctx, const u8 *addr,
+ 			 const u8 *ies, size_t ies_len, int frame_type)
+ {
+@@ -1826,6 +1837,7 @@ int hostapd_setup_wpa(struct hostapd_data *hapd)
+ 		.get_ml_key_info = hostapd_wpa_auth_get_ml_key_info,
+ #endif /* CONFIG_IEEE80211BE */
+ 		.get_drv_flags = hostapd_wpa_auth_get_drv_flags,
++		.get_handshake_status = hostapd_wpa_get_handshake_status,
+ 	};
+ 	const u8 *wpa_ie;
+ 	size_t wpa_ie_len;
+diff --git a/source/hostap-2.11/src/drivers/driver.h b/source/hostap-2.11/src/drivers/driver.h
+index 778c36a32..2c5cb7aad 100644
+--- a/source/hostap-2.11/src/drivers/driver.h
++++ b/source/hostap-2.11/src/drivers/driver.h
+@@ -5492,7 +5492,7 @@ struct wpa_driver_ops {
+ 			      const u8 *match, size_t match_len,
+ 			      bool multicast);
+ #endif /* CONFIG_TESTING_OPTIONS */
+-       int (*radius_eap_failure)(void *priv, int failure_reason);
++	int (*radius_eap_failure)(void *priv, const u8 *addr, int failure_reason);
+        int (*radius_fallback_failover)(void *priv, int radius_switch_reason);
+        /**
+         * get_sta_auth_type - Notify about Auth Type STA sent in Assoc/Reassoc Req
+@@ -5693,6 +5693,7 @@ struct wpa_driver_ops {
+ 	*/
+ 	int (*txpower_ctrl)(void *priv, u8 lpi_psd, u8 sku_idx, u8 lpi_bcn_enhance,
+ 			    u8 link_id, s8 **power_table, u8 lpi_mode);
++	int (*get_handshake_status)(void *priv, const u8 *addr, int status);
+ };
+ 
+ /**

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/kernel_6_6/xfi_tel_compete_2_11.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/kernel_6_6/xfi_tel_compete_2_11.patch
@@ -1,0 +1,202 @@
+diff --git a/source/hostap-2.11/src/ap/ap_drv_ops.c b/source/hostap-2.11/src/ap/ap_drv_ops.c
+index 31efc1af4..679e2b58f 100644
+--- a/source/hostap-2.11/src/ap/ap_drv_ops.c
++++ b/source/hostap-2.11/src/ap/ap_drv_ops.c
+@@ -913,12 +913,12 @@ int hostapd_drv_sta_deauth(struct hostapd_data *hapd,
+ 					reason, link_id);
+ }
+ 
+-int hostapd_drv_radius_eap_failure(struct hostapd_data *hapd,
++int hostapd_drv_radius_eap_failure(struct hostapd_data *hapd, const u8 *addr,
+                            int failure_reason)
+ {
+        if (!hapd->driver || !hapd->driver->radius_eap_failure || !hapd->drv_priv)
+                return 0;
+-       return hapd->driver->radius_eap_failure(hapd->drv_priv, failure_reason);
++       return hapd->driver->radius_eap_failure(hapd->drv_priv, addr, failure_reason);
+ }
+ 
+ int hostapd_drv_radius_fallback_failover(void *ctx, int radius_switch_reason)
+@@ -1286,7 +1286,12 @@ size_t hostapd_drv_eid_rnr_colocation_len(struct hostapd_data *hapd,
+ 
+ 	return hapd->driver->get_rnr_colocation_len(hapd->drv_priv, current_len);
+ }
+-
++int hostapd_drv_get_handshake_status(struct hostapd_data *hapd, const u8 *addr, int status)
++{
++	if(!hapd->driver || !hapd->driver->get_handshake_status)
++		return -1;
++	return hapd->driver->get_handshake_status(hapd->drv_priv, addr, status);
++}
+ int hostapd_drv_get_sta_auth_type(struct hostapd_data *hapd,
+ 					const u8 *addr, const u8 *ies, size_t ies_len, int frame_type)
+ {
+diff --git a/source/hostap-2.11/src/ap/ap_drv_ops.h b/source/hostap-2.11/src/ap/ap_drv_ops.h
+index f6a62ee28..b0975d7db 100644
+--- a/source/hostap-2.11/src/ap/ap_drv_ops.h
++++ b/source/hostap-2.11/src/ap/ap_drv_ops.h
+@@ -111,7 +111,7 @@ int hostapd_drv_send_mlme(struct hostapd_data *hapd,
+ 			  int no_encrypt);
+ int hostapd_drv_sta_deauth(struct hostapd_data *hapd,
+ 			   const u8 *addr, int reason);
+-int hostapd_drv_radius_eap_failure(struct hostapd_data *hapd, int failure_reason);
++int hostapd_drv_radius_eap_failure(struct hostapd_data *hapd, const u8 *addr, int failure_reason);
+ int hostapd_drv_radius_fallback_failover(void *ctx, int radius_switch_reason);
+ int hostapd_drv_sta_notify_deauth(struct hostapd_data *hapd,
+ 			   const u8 *addr, int reason);
+@@ -176,6 +176,8 @@ int hostapd_drv_set_secure_ranging_ctx(struct hostapd_data *hapd,
+ u8 * hostapd_drv_eid_ap_channel_report(struct hostapd_data *hapd, u8 *eid);
+ 
+ 
++int hostapd_drv_get_handshake_status(struct hostapd_data *hapd, const u8 *addr, int status);
++
+ #include "drivers/driver.h"
+ 
+ int hostapd_drv_wnm_oper(struct hostapd_data *hapd,
+diff --git a/source/hostap-2.11/src/ap/ieee802_1x.c b/source/hostap-2.11/src/ap/ieee802_1x.c
+index 4a6c07c14..760a6e03f 100644
+--- a/source/hostap-2.11/src/ap/ieee802_1x.c
++++ b/source/hostap-2.11/src/ap/ieee802_1x.c
+@@ -1672,10 +1672,11 @@ static void ieee802_1x_decapsulate_radius(struct hostapd_data *hapd,
+ 		break;
+ 	case EAP_CODE_SUCCESS:
+ 		os_strlcpy(buf, "EAP Success", sizeof(buf));
++                hostapd_drv_radius_eap_failure(hapd, sm->addr, DRV_EAP_SUCCESS);
+ 		break;
+ 	case EAP_CODE_FAILURE:
+ 		os_strlcpy(buf, "EAP Failure", sizeof(buf));
+-		hostapd_drv_radius_eap_failure(hapd, DRV_EAP_FAILURE);
++                hostapd_drv_radius_eap_failure(hapd, sm->addr, DRV_EAP_FAILURE);
+ 		break;
+ 	default:
+ 		os_strlcpy(buf, "unknown EAP code", sizeof(buf));
+@@ -2251,6 +2252,7 @@ ieee802_1x_receive_auth(struct radius_msg *msg, struct radius_msg *req,
+ 		if ((hapd->conf->rdk_greylist  || hapd->conf->connected_building_avp) && !hapd->conf->ieee802_1x)
+ 			ieee802_1x_set_sta_authorized(hapd, sta, 1);
+ #endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
++                hostapd_drv_radius_eap_failure(hapd, sm->addr, DRV_RADIUS_ACCESS_ACCEPT);
+ 		break;
+ 	case RADIUS_CODE_ACCESS_REJECT:
+ 		sm->eap_if->aaaFail = true;
+@@ -2293,7 +2295,7 @@ ieee802_1x_receive_auth(struct radius_msg *msg, struct radius_msg *req,
+ 			}
+ 		}
+ #endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+-		hostapd_drv_radius_eap_failure(hapd, DRV_RADIUS_ACCESS_REJECT);
++                hostapd_drv_radius_eap_failure(hapd, sm->addr, DRV_RADIUS_ACCESS_REJECT);
+ 		break;
+ 	case RADIUS_CODE_ACCESS_CHALLENGE:
+ 		sm->eap_if->aaaEapReq = true;
+diff --git a/source/hostap-2.11/src/ap/ieee802_1x.h b/source/hostap-2.11/src/ap/ieee802_1x.h
+index 43e75e004..5ddca6460 100644
+--- a/source/hostap-2.11/src/ap/ieee802_1x.h
++++ b/source/hostap-2.11/src/ap/ieee802_1x.h
+@@ -9,8 +9,10 @@
+ #ifndef IEEE802_1X_H
+ #define IEEE802_1X_H
+ 
++#define DRV_RADIUS_ACCESS_ACCEPT 0
+ #define DRV_RADIUS_ACCESS_REJECT 1
+ #define DRV_EAP_FAILURE 2
++#define DRV_EAP_SUCCESS 3
+ 
+ struct hostapd_data;
+ struct sta_info;
+diff --git a/source/hostap-2.11/src/ap/wpa_auth.c b/source/hostap-2.11/src/ap/wpa_auth.c
+index 2d61641b6..ecc333c4e 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth.c
++++ b/source/hostap-2.11/src/ap/wpa_auth.c
+@@ -41,7 +41,7 @@
+ #define STATE_MACHINE_DATA struct wpa_state_machine
+ #define STATE_MACHINE_DEBUG_PREFIX "WPA"
+ #define STATE_MACHINE_ADDR wpa_auth_get_spa(sm)
+-
++#define EAPOL_HS_SUCCESS 1
+ 
+ static void wpa_send_eapol_timeout(void *eloop_ctx, void *timeout_ctx);
+ static int wpa_sm_step(struct wpa_state_machine *sm);
+@@ -305,6 +305,13 @@ static inline int wpa_auth_set_key(struct wpa_authenticator *wpa_auth,
+ 				     key, key_len, key_flag);
+ }
+ 
++static void wpa_get_handshake_status(struct wpa_authenticator *wpa_auth, const u8 *addr, int status)
++{
++	if(!wpa_auth->cb->get_handshake_status)
++		return;
++	wpa_auth->cb->get_handshake_status(wpa_auth->cb_ctx, addr, status);
++}
++
+ static void wpa_auth_get_sta_auth_type(struct wpa_authenticator *wpa_auth, const u8 *addr,
+ 					const u8 *data, size_t data_len, int frame_type)
+ {
+@@ -5073,6 +5080,7 @@ SM_STATE(WPA_PTK, PTKINITDONE)
+ 			 sm->wpa == WPA_VERSION_WPA ? "WPA" : "RSN");
+ 	wpa_msg(sm->wpa_auth->conf.msg_ctx, MSG_INFO, "EAPOL-4WAY-HS-COMPLETED "
+ 		MACSTR, MAC2STR(sm->addr));
++	wpa_get_handshake_status(sm->wpa_auth, sm->addr, EAPOL_HS_SUCCESS);
+ 
+ #ifdef CONFIG_IEEE80211R_AP
+ 	wpa_ft_push_pmk_r1(sm->wpa_auth, wpa_auth_get_spa(sm));
+diff --git a/source/hostap-2.11/src/ap/wpa_auth.h b/source/hostap-2.11/src/ap/wpa_auth.h
+index 13fd4e835..c1c7814d0 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth.h
++++ b/source/hostap-2.11/src/ap/wpa_auth.h
+@@ -413,6 +413,7 @@ void (*get_sta_auth_type)(void *ctx, const u8 *addr,const u8 *ies, size_t ies_le
+ 	int (*get_ml_key_info)(void *ctx, struct wpa_auth_ml_key_info *info);
+ #endif /* CONFIG_IEEE80211BE */
+ 	int (*get_drv_flags)(void *ctx, u64 *drv_flags, u64 *drv_flags2);
++	void (*get_handshake_status)(void *ctx, const u8 *addr, int status);
+ };
+ 
+ struct wpa_authenticator * wpa_init(const u8 *addr,
+diff --git a/source/hostap-2.11/src/ap/wpa_auth_glue.c b/source/hostap-2.11/src/ap/wpa_auth_glue.c
+index a653c7659..3569f0ec5 100644
+--- a/source/hostap-2.11/src/ap/wpa_auth_glue.c
++++ b/source/hostap-2.11/src/ap/wpa_auth_glue.c
+@@ -1622,6 +1622,17 @@ static void hostapd_request_radius_psk(void *ctx, const u8 *addr, int key_mgmt,
+ }
+ #endif /* CONFIG_NO_RADIUS */
+ 
++static void hostapd_wpa_get_handshake_status(void *ctx, const u8 *addr, int status)
++{
++	struct hostapd_data *hapd = ctx;
++
++	if(!hapd){
++		wpa_printf(MSG_ERROR, "%s hapd is NULL", __func__);
++		return;
++	}
++	hostapd_drv_get_handshake_status(hapd, addr, status);
++}
++
+ static void hostapd_wpa_auth_get_sta_auth_type(void *ctx, const u8 *addr,
+ 			 const u8 *ies, size_t ies_len, int frame_type)
+ {
+@@ -1775,6 +1786,7 @@ int hostapd_setup_wpa(struct hostapd_data *hapd)
+ 		.get_ml_key_info = hostapd_wpa_auth_get_ml_key_info,
+ #endif /* CONFIG_IEEE80211BE */
+ 		.get_drv_flags = hostapd_wpa_auth_get_drv_flags,
++		.get_handshake_status = hostapd_wpa_get_handshake_status,
+ 	};
+ 	const u8 *wpa_ie;
+ 	size_t wpa_ie_len;
+diff --git a/source/hostap-2.11/src/drivers/driver.h b/source/hostap-2.11/src/drivers/driver.h
+index 9adcbe52e..dd798b8f6 100644
+--- a/source/hostap-2.11/src/drivers/driver.h
++++ b/source/hostap-2.11/src/drivers/driver.h
+@@ -5273,7 +5273,7 @@ struct wpa_driver_ops {
+ 			      const u8 *match, size_t match_len,
+ 			      bool multicast);
+ #endif /* CONFIG_TESTING_OPTIONS */
+-	int (*radius_eap_failure)(void *priv, int failure_reason);
++        int (*radius_eap_failure)(void *priv, const u8 *addr, int failure_reason);
+ 	int (*radius_fallback_failover)(void *priv, int radius_switch_reason);
+ 	/**
+ 	 * get_sta_auth_type - Notify about Auth Type STA sent in Assoc/Reassoc Req
+@@ -5296,6 +5296,7 @@ struct wpa_driver_ops {
+ 			u8 **elem_offset);
+ 	u8* (*get_mbssid_config)(void *priv, u8 *eid);
+     u8* (*get_ap_channel_report_ie)(void *priv, u8 *eid);
++	int (*get_handshake_status)(void *priv, const u8 *addr, int status);
+ };
+ 
+ /**


### PR DESCRIPTION
Reason for change: rdk-wifi-hal recent changes require this patch for compilation.