### PR TITLE
RDKBACCL-1518 : Phase-I Enabling Remote-debugger in BPI-R4 reference platform

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -67,6 +67,5 @@ DISTRO_FEATURES_append = " generic_mlo"
 #Enable the below DISTRO to enable Hybrid Hal(rndis/modem) for cellular devices
 #DISTRO_FEATURES_append_broadband = " cellular_hybrid_support"
 
-#Disable rdm-agent for reference platform
-DISTRO_FEATURES_append = " RDM"
+#Enable remote debugger
 DISTRO_FEATURES_append = " rrd"

--- a/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -7,7 +7,7 @@ IMAGE_INSTALL_append = " bpi-serialnumber"
 IMAGE_INSTALL_append = " bpi-macaddress"
 
 
-IMAGE_INSTALL_append = " rdk-speedtest-cli rdm-agent remotedebugger"
+IMAGE_INSTALL_append = " rdk-speedtest-cli rdm-agent ${@bb.utils.contains('DISTRO_FEATURES', 'rrd', ' remotedebugger', " ", d)}"
 #Enable required linux utils for Fwupgrade
 IMAGE_INSTALL_append = " gptfdisk e2fsprogs-mke2fs util-linux util-linux-losetup coreutils"
 


### PR DESCRIPTION
Reason for change : Clean of RDM distro in BPI-R4
Risks: Low
Test Procedure: None