### PR TITLE
RDKBACCL-1533 : Observing build issues in tip (i,e Mar18)

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -15,6 +15,7 @@ CFLAGS_append_aarch64 = " -Wno-error "
 
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-em-app ', '', d)}"
 CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' -DEASY_MESH_NODE ', '', d)}"
+CFLAGS_append = " -DFEATURE_SINGLE_PHY"
 
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'sta_manager', 'ONEWIFI_STA_MGR_APP_SUPPORT=true', 'ONEWIFI_STA_MGR_APP_SUPPORT=false', d)}"
 CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'sta_manager', '-DONEWIFI_STA_MGR_APP_SUPPORT', '', d)}"


### PR DESCRIPTION
Reason for change: Observing below errors
source/core/services/vap_svc_mesh_ext.c:742: undefined reference to `wifi_hal_rnr_init' | collect2:
 error: ld returned 1 exit status
this issue is caused by https://github.com/rdkcentral/rdk-wifi-hal/pull/613
 Test Procedure: Build is successful
Risks: Low