### PR TITLE
RDKBACCL-1539 : Observing build errors in linux kernel 5.4

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/kernel_5_4/patches.inc
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11/kernel_5_4/patches.inc
@@ -37,4 +37,5 @@ SRC_URI:append = " \
     file://bpi.patch \
     file://mlo_fix.patch \
     file://fixed_disassoc_after_assoc_retry.patch \
+    file://xfi_tel_compete_2_11.patch \
     "


### PR DESCRIPTION
Reason for change: rdk-wifi-libhostap build is breaking with below errors
error: initialization of 'int (*)(void *, int)' from incompatible pointer type 'int (*)(void *, const u8 *, int)' {aka 'int (*)(void *, const unsigned char *, int)'} [-Werror=incompatible-pointer-types]
Test Procedure: Build successful
Risks: Low