### PR TITLE
RDKBACCL-1526: RNDIS is not working in DHCPManager build

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-dhcp-mgr.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-dhcp-mgr.bbappend
@@ -1,3 +1,6 @@
 include ccsp_common_bananapi.inc
 
 CFLAGS_append  = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '-DFEATURE_RDKB_WAN_MANAGER', '', d)}"
+
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
+SRC_URI:append = " file://0001-RDKBDEV-3401-RDKBACCL-1526-RNDIS-interface-is-not-wo.patch"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/0001-RDKBDEV-3401-RDKBACCL-1526-RNDIS-interface-is-not-wo.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/0001-RDKBDEV-3401-RDKBACCL-1526-RNDIS-interface-is-not-wo.patch
@@ -1,0 +1,32 @@
+From 26d12002cdff48e61fa4f895bd0d299f776c1fcb Mon Sep 17 00:00:00 2001
+From: Manigandan Gopalakrishnan <Manigandan_Gopalakrishnan@comcast.com>
+Date: Tue, 17 Mar 2026 18:25:54 +0530
+Subject: [PATCH] RDKBDEV-3401, RDKBACCL-1526: RNDIS interface is not working
+ when DHCPManager is enabled
+
+Reason for change: MTU is set to 0, so usb0 interface is not having IP
+Test procedure: Able to ping Internet through usb0
+Risks: Low
+
+Signed-off-by: Manigandan Gopalakrishnan <Manigandan_Gopalakrishnan@comcast.com>
+---
+ source/DHCPMgrUtils/dhcpmgr_v4_lease_handler.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/source/DHCPMgrUtils/dhcpmgr_v4_lease_handler.c b/source/DHCPMgrUtils/dhcpmgr_v4_lease_handler.c
+index 7acb052..ad71897 100644
+--- a/source/DHCPMgrUtils/dhcpmgr_v4_lease_handler.c
++++ b/source/DHCPMgrUtils/dhcpmgr_v4_lease_handler.c
+@@ -356,6 +356,9 @@ void DhcpMgr_ProcessV4Lease(PCOSA_DML_DHCPC_FULL pDhcpc)
+                 DhcpMgr_PublishDhcpV4Event(pDhcpc, DHCP_LEASE_DEL);
+                 continue;
+             }
++            //If DHCP server is not sending MTU, setting the default value of 1500. Can't set 0 as MTU
++            if(newLease->mtuSize == 0)
++                newLease->mtuSize = 1500;
+             DHCPMGR_LOG_INFO("%s %d: NewLease->address %s  \n",__FUNCTION__, __LINE__, newLease->address);
+             DHCPMGR_LOG_INFO("%s %d: NewLease->netmask %s  \n",__FUNCTION__, __LINE__, newLease->netmask);
+             DHCPMGR_LOG_INFO("%s %d: NewLease->gateway %s  \n",__FUNCTION__, __LINE__, newLease->gateway );
+-- 
+2.17.1
+


### PR DESCRIPTION
Reason for change: Temporarily applying approved fix as patch
Test procedure: Found that the patch is applied
Risks: None