### PR TITLE
RDKBACCL-1524: Update SRCREV for hal-fwupgrade

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-fwupgrade.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-fwupgrade.bbappend
@@ -8,7 +8,7 @@ SRC_URI_append = "git://github.com/rdkcentral/rdkb-hal-bpi;branch=develop;protoc
                 "
 LIC_FILES_CHKSUM = "file://../../LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRCREV_fwupgradehal = "a18b3f87fe30b5de5c983799bf06b16703e192ee"
+SRCREV_fwupgradehal = "2d25cbb860419bd5f9e5ba2511524d8eec3245e4"
 do_install_append () {
          install -d ${D}${bindir}
         install -v -m 0755 ${WORKDIR}/start_cron.sh ${D}${bindir}/start_cron


### PR DESCRIPTION
Reason For Change: updating the latest src-rev for hal-fwupgarde.
Test Procedure: Firmware should work as expected.
Risks: None