### PR TITLE
RDKBACCL-1620 : backhaul is not connecting in recent default easymesh builds

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-ap-extender.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-core/packagegroups/packagegroup-ap-extender.bbappend
@@ -15,5 +15,6 @@ RDEPENDS_packagegroup-ap-extender = "\
     bpi-macaddress \
     bpi-serialnumber \
     mount-nvram \
+    e2fsprogs-mke2fs \
 "
 DEPENDS += " ccsp-common-library"

--- a/meta-rdk-mtk-bpir4/recipes-nonvol/persistence/files/mount-nvram.sh
+++ b/meta-rdk-mtk-bpir4/recipes-nonvol/persistence/files/mount-nvram.sh
@@ -39,7 +39,9 @@ mkdir -p /nvram/secure
 mkdir -p /opt/secure
 mount --bind /nvram /opt/secure
 # MariaDB stored under /var/lib/mysql
+if [ -f /lib/systemd/system/mysqld.service ] ; then
 mkdir -p /var/lib/mysql
 mount --bind /nvram /var/lib/mysql
+fi
 
 exit 0


### PR DESCRIPTION
Reason for change: e2fsprogs-mke2fs package is missing in extender builds due to that Lan-Bridge service is not started 
Test Procedure:Build successful and basic functionality is working 
Risks: Low