### PR TITLE
RDKBACCL-1603: >95% CPU Utilisation observed for CcspDHCPMgr service

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-dhcp-mgr.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-dhcp-mgr.bbappend
@@ -2,3 +2,7 @@ include ccsp_common_bananapi.inc
 
 CFLAGS_append  = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '-DFEATURE_RDKB_WAN_MANAGER', '', d)}"
 CFLAGS_append  += " ${@bb.utils.contains('DISTRO_FEATURES', 'dhcp_manager', '-DFEATURE_RDKB_DHCP_MANAGER', '', d)}"
+
+do_install_append() {
+   sed -i 's/PsmSsp.service/& ApplySystemDefaults.service/' ${D}/lib/systemd/system/CcspDHCPMgr.service
+}


### PR DESCRIPTION
Reason for change: sysevent_getnotification is failing due to other service dependency
Test procedure: CcspDHCPMgr is using 0.2% CPU
Risks: Low