### PR TITLE
RDKBACCL-1526, RDKBACCL-1603: RNDIS is not working with PR 410, >95% CPU Utilisation observed for CcspDHCPMgr service

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-dhcp-mgr.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-dhcp-mgr.bbappend
@@ -1,4 +1,10 @@
 include ccsp_common_bananapi.inc
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
 CFLAGS_append  = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '-DFEATURE_RDKB_WAN_MANAGER', '', d)}"
 CFLAGS_append  += " ${@bb.utils.contains('DISTRO_FEATURES', 'dhcp_manager', '-DFEATURE_RDKB_DHCP_MANAGER', '', d)}"
+
+SRC_URI_append = " \
+    file://0001_CPU_Utilisation_and_RNDIS_changes.patch \
+"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/0001_CPU_Utilisation_and_RNDIS_changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/0001_CPU_Utilisation_and_RNDIS_changes.patch
@@ -1,0 +1,72 @@
+SOURCE: RDKM and https://github.com/rdkcentral/dhcp-manager/pull/85, https://github.com/rdkcentral/dhcp-manager/pull/94
+
+From e41564e2e3521677ab5538620ef8ea55d6c54175 Mon Sep 17 00:00:00 2001
+From: Manigandan Gopalakrishnan <Manigandan_Gopalakrishnan@comcast.com>
+Date: Wed, 1 Apr 2026 20:39:01 +0530
+Subject: [PATCH] RDKBDEV-3416, RDKBACCL-1603: >95% CPU Utilisation observed
+ for CcspDHCPMgr service
+
+Reason for change: Adding timeout to avoid continuous loop execution in
+case of getnotification failure
+Test procedure: Found that cpu utilization is under 0.5%
+Risks: None
+
+Signed-off-by: Manigandan Gopalakrishnan <Manigandan_Gopalakrishnan@comcast.com>
+---
+ source/DHCPMgrInterface/ifl.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/source/DHCPMgrInterface/ifl.c b/source/DHCPMgrInterface/ifl.c
+index 6c02fbfc..ca0bedc2 100644
+--- a/source/DHCPMgrInterface/ifl.c
++++ b/source/DHCPMgrInterface/ifl.c
+@@ -633,11 +633,10 @@ static void *_task_manager_thrd(void * value)
+         err = sysevent_getnotification(sysevent_fd, sysevent_token, event, &eventLen,
+                                       eValue, &eValueLen, &getnotification_id);
+ 
+-        IFL_LOG_INFO("Event getting triggered is [%s]", event);
+-
+         if (err)
+         {
+             IFL_LOG_ERROR("Sysevent get notification failed! err: %d", err);
++            sleep(2);
+         }
+         else
+         {
+@@ -645,6 +644,7 @@ static void *_task_manager_thrd(void * value)
+             uint8 ctxID = 0;
+             uint8 idx   = 0;
+ 
++            IFL_LOG_INFO("Event getting triggered is [%s]", event);
+             /* _get_evt_id is not thread safe */
+             evtID = _get_evt_id(event, 0);
+           
+From f60f57e0b9590ae70a33b8e55d91c6fe2d71b747 Mon Sep 17 00:00:00 2001
+From: Manigandan Gopalakrishnan <Manigandan_Gopalakrishnan@comcast.com>
+Date: Tue, 17 Mar 2026 18:25:54 +0530
+Subject: [PATCH] RDKBDEV-3401, RDKBACCL-1526: RNDIS interface is not working
+ when DHCPManager is enabled
+
+Reason for change: MTU is set to 0, so usb0 interface is not having IP
+Test procedure: Able to ping Internet through usb0
+Risks: Low
+
+Signed-off-by: Manigandan Gopalakrishnan <Manigandan_Gopalakrishnan@comcast.com>
+---
+ source/DHCPMgrUtils/dhcpmgr_v4_lease_handler.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/source/DHCPMgrUtils/dhcpmgr_v4_lease_handler.c b/source/DHCPMgrUtils/dhcpmgr_v4_lease_handler.c
+index 7acb0524..ad718974 100644
+--- a/source/DHCPMgrUtils/dhcpmgr_v4_lease_handler.c
++++ b/source/DHCPMgrUtils/dhcpmgr_v4_lease_handler.c
+@@ -356,6 +356,9 @@ void DhcpMgr_ProcessV4Lease(PCOSA_DML_DHCPC_FULL pDhcpc)
+                 DhcpMgr_PublishDhcpV4Event(pDhcpc, DHCP_LEASE_DEL);
+                 continue;
+             }
++            //If DHCP server is not sending MTU, setting the default value of 1500. Can't set 0 as MTU
++            if(newLease->mtuSize == 0)
++                newLease->mtuSize = 1500;
+             DHCPMGR_LOG_INFO("%s %d: NewLease->address %s  \n",__FUNCTION__, __LINE__, newLease->address);
+             DHCPMGR_LOG_INFO("%s %d: NewLease->netmask %s  \n",__FUNCTION__, __LINE__, newLease->netmask);
+             DHCPMGR_LOG_INFO("%s %d: NewLease->gateway %s  \n",__FUNCTION__, __LINE__, newLease->gateway );


### PR DESCRIPTION
Reason for Change: Adding the PR changes as a patch.
Test Procedure: ccsp-dhcp-mgr compilation should be successful.
Risks: Low.