### PR TITLE
RDKBACCL-1637: New ccsp-dhcp-mgr import change is not building

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -2,15 +2,6 @@ include ccsp_common_bananapi.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:${THISDIR}/files:"
 
-SRC_URI:remove = "${CMF_GITHUB_ROOT}/common-library;protocol=https;${BRANCH_ccsp_common_library}"
-
-PV_pn-ccsp-common-library = "2.0.0_stable2_20260109"
-SRC_URI:append = "git://github.com/rdkcentral/common-library.git;protocol=https;name=ccsp_common_library;branch=support/2026q1"
-SRCREV_ccsp_common_library = "740a897df8d1b6525b632862814c9ce1cfa4f991"
-
-PV_pn-ccsp-common-library-native = "2.0.0_stable2_20260109"
-SRCREV_pn-ccsp-common-library-native = "740a897df8d1b6525b632862814c9ce1cfa4f991"
-
 SRC_URI_append = " \
                    file://gwprovapp.conf \
                 "

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
@@ -1,6 +1,2 @@
 include ccsp_common_bananapi.inc
 RDEPENDS_${PN} += "ndisc6"
-
-GIT_TAG = "v2.14.0"
-SRC_URI = "git://github.com/rdkcentral/wan-manager.git;branch=releases/2.14.0-main;protocol=https;name=WanManager;tag=${GIT_TAG}"
-SRCREV = ""


### PR DESCRIPTION
Reason for change : Removing the hardcoded srcrev for ccsp-common and rdk-wanmanager as dhcp manager srcrev is updated in latest import change.
Test Procedure: Build should succeed without any error, dhcp manager should be up and running
Risks: None