### PR TITLE
RDKBACCL-1685: [WiFiagent] Unable to connect WiFi clients

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/linux-mac80211_6.%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/linux-mac80211_6.%.bbappend
@@ -2,4 +2,4 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI:append = " file://1000-get-station-increase-buffer-size.patch "
 SRC_URI:append = " file://1001-BPIR4_Enable_Beacon_Frame_Subscription.patch "
-SRC_URI:append = " file://1002-MAC-ACL-support-for-BPI.patch "
+SRC_URI:append = "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' file://1002-MAC-ACL-support-for-BPI.patch', ' ', d)}"


### PR DESCRIPTION
Reason for Change: Driver-level crash(seen in backtrace) is triggered by the MAC ACL patch in wifiagent builds, causing hostapd restart and client connectivity issues.
Test Procedure: Verify WiFi clients can connect to the network and confirm no hostapd crash/restart is observed
Risks: Low