### PR TITLE
RDKBWIFI-409 : [TDK][AUTO] Controller/Extender Radio DataElements Partially Missing and Incorrect in Latest EM Build

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ctrl.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ctrl.sh
@@ -9,6 +9,9 @@ fi
 if [ ! -f /nvram/EasymeshCfg.json ]; then
    cp /usr/ccsp/EasyMesh/EasymeshCfg.json /nvram
 fi
+if [ ! -f /nvram/Data_Elements_JSON_Schema_v3.0.json ]; then
+   cp /usr/ccsp/EasyMesh/Data_Elements_JSON_Schema_v3.0.json /nvram
+fi
 if [ ! -f /nvram/Reset.json ]; then
    cp /usr/ccsp/EasyMesh/Reset.json /nvram
 fi

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ext.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/files/onewifi_pre_start_em_ext.sh
@@ -9,6 +9,9 @@ fi
 if [ ! -f /nvram/EasymeshCfg.json ]; then
    cp /usr/ccsp/EasyMesh/EasymeshCfg.json /nvram
 fi
+if [ ! -f /nvram/Data_Elements_JSON_Schema_v3.0.json ]; then
+   cp /usr/ccsp/EasyMesh/Data_Elements_JSON_Schema_v3.0.json /nvram
+fi
 
 sleep 5
 


### PR DESCRIPTION
Reason for change: Moved nvram to different partitions. This partition will be created during run-time . So, need to remove build time nvram changes 
Test Procedure: Build successful and able to load the TR-181 DM 
Risks: Low