### PR TITLE
RDKBACCL-1685: [WiFiagent] Unable to connect WiFi clients

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -2,15 +2,6 @@ include ccsp_common_bananapi.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:${THISDIR}/files:"
 
-SRC_URI:remove = "${CMF_GITHUB_ROOT}/common-library;protocol=https;${BRANCH_ccsp_common_library}"
-
-PV_pn-ccsp-common-library = "2.0.0_stable2_20260109"
-SRC_URI:append = "git://github.com/rdkcentral/common-library.git;protocol=https;name=ccsp_common_library;branch=support/2026q1"
-SRCREV_ccsp_common_library = "740a897df8d1b6525b632862814c9ce1cfa4f991"
-
-PV_pn-ccsp-common-library-native = "2.0.0_stable2_20260109"
-SRCREV_pn-ccsp-common-library-native = "740a897df8d1b6525b632862814c9ce1cfa4f991"
-
 SRC_URI_append = " \
                    file://gwprovapp.conf \
                 "

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=libwebconfig"
 
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=libwebconfig"
-SRCREV_libwebconfig = "4bc321930ccdacad095b161cf9fb6a2a9e14a527"
+SRCREV_libwebconfig = "5b8d311914f93df0f9bc591f56a5907a08927cc7"
 
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap unified-wifi-mesh-header ', '', d)}"
 EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' --enable-easymesh ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-one-wifi.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/components/opensource/ccsp/OneWifi;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};name=OneWifi"
 SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=develop;name=OneWifi"
-SRCREV_OneWifi = "4bc321930ccdacad095b161cf9fb6a2a9e14a527"
+SRCREV_OneWifi = "5b8d311914f93df0f9bc591f56a5907a08927cc7"
 DEPENDS_append = " mesh-agent "
 DEPENDS_remove = " opensync "
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' rdk-wifi-libhostap ', '', d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
@@ -1,6 +1,2 @@
 include ccsp_common_bananapi.inc
 RDEPENDS_${PN} += "ndisc6"
-
-GIT_TAG = "v2.14.0"
-SRC_URI = "git://github.com/rdkcentral/wan-manager.git;branch=releases/2.14.0-main;protocol=https;name=WanManager;tag=${GIT_TAG}"
-SRCREV = ""

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -1,7 +1,7 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
 
 SRC_URI += "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-hal"
-SRCREV_rdk-wifi-hal = "63e8633ea7d4bb5dd77cc987086619517256af26"
+SRCREV_rdk-wifi-hal = "e936e86ef9edf5b481a258138991823ca34b3cfa"
 
 CFLAGS_append = " -D_PLATFORM_BANANAPI_R4_  -DBANANA_PI_PORT  -DFEATURE_SINGLE_PHY -DCONFIG_HW_CAPABILITIES "
 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-util.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_remove = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-util"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=develop;name=rdk-wifi-util"
-SRCREV_rdk-wifi-util = "63e8633ea7d4bb5dd77cc987086619517256af26"
+SRCREV_rdk-wifi-util = "e936e86ef9edf5b481a258138991823ca34b3cfa"

--- a/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/linux-mac80211_6.%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-wifi/linux-mac80211/linux-mac80211_6.%.bbappend
@@ -2,4 +2,4 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI:append = " file://1000-get-station-increase-buffer-size.patch "
 SRC_URI:append = " file://1001-BPIR4_Enable_Beacon_Frame_Subscription.patch "
-SRC_URI:append = " file://1002-MAC-ACL-support-for-BPI.patch "
+SRC_URI:append = "${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' file://1002-MAC-ACL-support-for-BPI.patch', ' ', d)}"


### PR DESCRIPTION
Reason for Change: Driver-level crash(seen in backtrace) is triggered by the MAC ACL patch in wifiagent builds, causing hostapd restart and client connectivity issues.
Test Procedure: Verify WiFi clients can connect to the network and confirm no hostapd crash/restart is observed
Risks: Low