### PR TITLE
RDKBACCL-1651 : Observing build issues when we disable generic_mlo distro in BPI RDKB builds

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/disabling_mlo_build_fix.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/disabling_mlo_build_fix.patch
@@ -1,0 +1,40 @@
+diff --git a/platform/banana-pi/platform.c b/platform/banana-pi/platform.c
+index 3b86fd1..007db25 100644
+--- a/platform/banana-pi/platform.c
++++ b/platform/banana-pi/platform.c
+@@ -823,7 +823,7 @@ INT wifi_setApManagementFramePowerControl(INT apIndex, INT dBm)
+     return 0;
+ }
+ 
+-#ifdef CONFIG_IEEE80211BE
++#if defined(CONFIG_IEEE80211BE) && defined(CONFIG_MLO)
+ int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,
+     struct wpa_driver_ap_params *params)
+ {
+@@ -841,7 +841,9 @@ int nl80211_send_mlo_msg(struct nl_msg *msg)
+ 
+     return 0;
+ }
++#endif /* CONFIG_IEEE80211BE && CONFIG_MLO */
+ 
++#if defined(CONFIG_IEEE80211BE)
+ void wifi_drv_get_phy_eht_cap_mac(struct eht_capabilities *eht_capab, struct nlattr **tb)
+ {
+     if (tb[NL80211_BAND_IFTYPE_ATTR_EHT_CAP_MAC] &&
+@@ -852,7 +854,9 @@ void wifi_drv_get_phy_eht_cap_mac(struct eht_capabilities *eht_capab, struct nla
+         eht_capab->mac_cap = WPA_GET_LE16(pos);
+     }
+ }
++#endif /* CONFIG_IEEE80211BE */
+ 
++#if defined(CONFIG_IEEE80211BE) && defined(CONFIG_MLO)
+ static struct hostapd_mld *find_mld(struct wifi_interface_info_t *interface)
+ {
+     struct hostapd_mld *mld_it = NULL;
+@@ -994,5 +998,5 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
+ #endif
+     return 0;
+ }
+-#endif /* CONFIG_IEEE80211BE */
++#endif /* CONFIG_IEEE80211BE && CONFIG_MLO */
+ 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -17,6 +17,7 @@ EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', ' BAN
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
+  file://disabling_mlo_build_fix.patch;patchdir=../ \
   ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', ' file://InterfaceMap_em.json ', 'file://InterfaceMap.json ', d)} \
   ${@bb.utils.contains('DISTRO_FEATURES', 'EasyMesh', bb.utils.contains('DISTRO_FEATURES', 'em_extender', 'file://EasymeshCfg_ext.json ','file://EasymeshCfg.json ', d), ' ', d)} \
 "


### PR DESCRIPTION
Reason for change: Observed below errors,
../git/src/../platform/banana-pi/platform.c:860:44: error: 'wifi_hal_priv_t' has no member named 'mld_count' | 860 | for (unsigned int i = 0; i < g_wifi_hal.mld_count; ++i) { | | ^
| ../git/src/../platform/banana-pi/platform.c:861:28: error: 'wifi_hal_priv_t' has no member named 'mld_array' | 861 | mld_it = g_wifi_hal.mld_array[i];
| | ^
| ../git/src/../platform/banana-pi/platform.c: In function 'alloc_mld': | ../git/src/../platform/banana-pi/platform.c:909:39: error: 'wifi_hal_priv_t' has no member named 'mld_array' | 909 | new_mld_array = realloc(g_wifi_hal.mld_array, | | ^
| ../git/src/../platform/banana-pi/platform.c:910:20: error: 'wifi_hal_priv_t' has no member named 'mld_count' | 910 | (g_wifi_hal.mld_count + 1) * sizeof(struct hostapd_mld *)); | | ^
| ../git/src/../platform/banana-pi/platform.c:924:29: error: 'wifi_hal_priv_t' has no member named 'mld_count' | 924 | new_mld_array[g_wifi_hal.mld_count] = mld; | | ^
| ../git/src/../platform/banana-pi/platform.c:926:15: error: 'wifi_hal_priv_t' has no member named 'mld_array' | 926 | g_wifi_hal.mld_array = new_mld_array;
| | ^
| ../git/src/../platform/banana-pi/platform.c:928:15: error: 'wifi_hal_priv_t' has no member named 'mld_count' | 928 | g_wifi_hal.mld_count++;
Test Procedure: Build successful
Risks: None