### PR TITLE
RDKBACCL-1755: [WiFiagent] LAN clients are not working after device reboot in Bridge mode

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-devtools/init-filogic/init-filogic.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-devtools/init-filogic/init-filogic.bbappend
@@ -27,6 +27,7 @@ fi' ${D}${sbindir}/init-bridge.sh
 #Mounting nvram
    sed -i '/Before=CcspPandMSsp.service/a Requires=mount-nvram.service' ${D}/lib/systemd/system/init-Lanbridge.service
    sed -i 's/utopia.service/mount-nvram.service &/' ${D}/lib/systemd/system/init-Lanbridge.service
+   sed -i '/After=hostapd.service/d' ${D}/lib/systemd/system/init-IPv6.service
 }
 
 #ESDK support - Avoid conflict file is installed by both systemd and init-filogic in kirkstone


### PR DESCRIPTION
Reason for Change: Erouter0 is not added to bridge upon reboot in Bridge-mode.
Test Procedure: Ensure that Lan client is getting the IP and internet in reboot(Bridge-mode)
Risks: None