### PR TITLE
RDKBACCL-1773: Intermittently facing build error in jenkins vm for linux-mt76

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-wifi/linux-mt76/linux-mt76_%.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-wifi/linux-mt76/linux-mt76_%.bbappend
@@ -1,0 +1,2 @@
+#Installing header files from mac80211 before mt76 compiles
+do_compile[depends] += "linux-mac80211:do_install" 


### PR DESCRIPTION
Reason for change: Installing header files from mac80211 before mt76 compiles
Test procedure: Build should be successful
Risks: None