### PR TITLE
RDKBACCL-1514: Enable bridgeutils in banana pi R4

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -7,6 +7,8 @@ DISTRO_FEATURES_append = " rdkb_wan_manager"
 
 DISTRO_FEATURES_append = " halVersion3"
 
+DISTRO_FEATURES_append = " bridgeUtilsBin"
+
 #rdk-wifi-libhostap support for broadband
 DISTRO_FEATURES_append = " HOSTAPD_2_11"
 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-misc.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-misc.bbappend
@@ -1,5 +1,23 @@
 include ccsp_common_bananapi.inc
+inherit breakpad-wrapper
+
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','halinterface','',d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','hal-bridgeutil','',d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','breakpad','',d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','breakpad-wrapper','',d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','ovs-agent','',d)}"
 
 CFLAGS_aarch64_append = "-Werror=format-truncation=1"
 
 CFLAGS += " -DDHCPV4_CLIENT_UDHCPC -DDHCPV6_CLIENT_DIBBLER -DUDHCPC_RUN_IN_BACKGROUND"
+
+EXTRA_OECONF += "${@bb.utils.contains("DISTRO_FEATURES", "bridgeUtilsBin", " --enable-bridgeUtilsBin=yes ", " ", d)}"
+
+CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '-DRDK_ONEWIFI', '', d)}"
+LDFLAGS_append = "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin',' -lOvsAgentApi ',' ',d)}"
+
+BREAKPAD_BIN_append = "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','bridgeUtils','',d)}"
+
+# generating minidumps
+
+PACKAGECONFIG_append = "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','breakpad',' ',d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp_common_bananapi.inc
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp_common_bananapi.inc
@@ -14,6 +14,7 @@ CFLAGS_append  += " ${@bb.utils.contains('DISTRO_FEATURES', 'WanFailOverSupportE
 CFLAGS_append  += " ${@bb.utils.contains('DISTRO_FEATURES', 'WanManagerUnificationEnable', '-DWAN_MANAGER_UNIFICATION_ENABLED', '', d)}"
 CFLAGS_append += "${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', ' -DFEATURE_RDKB_WAN_MANAGER ', '', d)}"
 CFLAGS_append  += " ${@bb.utils.contains('DISTRO_FEATURES', 'dhcp_manager', '-DFEATURE_RDKB_DHCP_MANAGER', '', d)}"
+CFLAGS_append += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin',' -D_BRIDGE_UTILS_BIN_ ','',d)}"
 
 DEPENDS += "breakpad-wrapper"
 LDFLAGS += "-lbreakpadwrapper"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-bridgeutil.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-bridgeutil.bbappend
@@ -1,0 +1,1 @@
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','libsyswrapper','',d)}"


### PR DESCRIPTION
Reason for change :
1) Enabling bridgeutils in BPI.
2) Taking gerrit code to make RFC feature to work until the BPI device is compatible with the github code. Test Procedure: Verify bridge mode functionality is is working or not. Risks: None