### PR TITLE
RDKBACCL-1790: New rdm-agent import change is not building

### DIFF
--- a/setup-environment-refboard-rdkb
+++ b/setup-environment-refboard-rdkb
@@ -84,11 +84,14 @@ touch ${_TOPDIR}/meta-filogic/recipes-wifi/hal/mt76_hal_change
 fi
 
 if [ ! -e ${_TOPDIR}/meta-rdk/recipes-common/rdm-agent/rdm_hal_change ]; then
-sed -i '77 s/^/#/' ${_TOPDIR}/meta-rdk/recipes-common/rdm-agent/rdm-agent.bb
-sed -i '78 s/^/#/' ${_TOPDIR}/meta-rdk/recipes-common/rdm-agent/rdm-agent.bb
-sed -i '79 s/^/#/' ${_TOPDIR}/meta-rdk/recipes-common/rdm-agent/rdm-agent.bb
-sed -i '80 s/^/#/' ${_TOPDIR}/meta-rdk/recipes-common/rdm-agent/rdm-agent.bb
-touch ${_TOPDIR}/meta-rdk/recipes-common/rdm-agent/rdm_hal_change
+    sed -i \
+        -e '/librdmopenssl/d' \
+        -e '/rdm_rsa_signature_verify/d' \
+        -e '/install -d.*\${D}\${includedir}\/rdm$/d' \
+        -e '/install -d.*\${D}\${libdir}$/d' \
+        -e 's/\(rdm\/\*\) \\$/\1"/' \
+        ${_TOPDIR}/meta-rdk/recipes-common/rdm-agent/rdm-agent.bb
+    touch ${_TOPDIR}/meta-rdk/recipes-common/rdm-agent/rdm_hal_change
 fi
 
 


### PR DESCRIPTION
Reason for change: Currently we don't have full support on rdm, removed the la libraries which are not builded.
Test Procedure: Build should succeed and sanity should pass for reference platform.
Risks: Low