### PR TITLE
RDKBACCL-1825: Facing build error in latest BPI RDKB image

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/Add_ipv6_changes.patch
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/files/Add_ipv6_changes.patch
@@ -5,14 +5,6 @@ Index: platform/rdkb_hal/src/platform/platform_hal.c
 ===================================================================
 --- platform.orig/rdkb_hal/src/platform/platform_hal.c
 +++ platform/rdkb_hal/src/platform/platform_hal.c
-@@ -20,6 +20,7 @@
- #include <stdio.h>
- #include <stdlib.h>
- #include <string.h>
-+#include <unistd.h>
- 
- #include "platform_hal.h" 
- 
 @@ -28,6 +29,22 @@
  /* Note that 0 == RETURN_OK == STATUS_OK    */
  /* Note that -1 == RETURN_ERR == STATUS_NOK */


### PR DESCRIPTION
Reason For Change: Observing hunk failure in patch file Add_ipv6_changes.patch, some change got merged in generic code, hence removing it from patch file
Test Procedure: Build should be successful and functionality should work.
Risks: None