### PR TITLE
Observing hunk failure in 2025q4 build

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-platform-generic_git.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/hal/hal-platform-generic_git.bbappend
@@ -1,5 +1,11 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
+SRC_URI:remove = "git://git01.mediatek.com/filogic/rdk-b/rdkb_hal;branch=master;protocol=https;destsuffix=git/source/platform/rdkb_hal"
+SRC_URI:append = " \
+    git://git01.mediatek.com/filogic/rdk-b/rdkb_hal;branch=master;protocol=https;name=rdkb_hal;destsuffix=git/source/platform/rdkb_hal \
+"
+SRCREV_rdkb_hal = "31f5afb748ea66ec4f08f6f5b325a22f73223f02"
+
 SRC_URI_append = " file://Add_ipv6_changes.patch"
 SRC_URI_append = " file://bpi_serial_no_fix.patch"
 SRC_URI_append = " file://hal-function-changes.patch"


### PR DESCRIPTION
Reason For Change: Observing hunk failure in patch file Add_ipv6_changes.patch, some change got merged in generic code, added fixed srcrev for mediatek hal platform repo
Test Procedure: Build should be successful and functionality should work.
Risks: None