### PR TITLE
RDKBACCL-1514: Enable bridgeutils in banana pi R4

### DIFF
--- a/conf/distro/include/rdk-bpi.inc
+++ b/conf/distro/include/rdk-bpi.inc
@@ -7,6 +7,8 @@ DISTRO_FEATURES_append = " rdkb_wan_manager"
 
 DISTRO_FEATURES_append = " halVersion3"
 
+DISTRO_FEATURES_append = " bridgeUtilsBin"
+
 #rdk-wifi-libhostap support for broadband
 DISTRO_FEATURES_append = " HOSTAPD_2_11"
 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-misc.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-misc.bbappend
@@ -9,7 +9,7 @@ DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','breakpad-wr
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','ovs-agent','',d)}"
 
 CFLAGS += " -DDHCPV4_CLIENT_UDHCPC -DDHCPV6_CLIENT_DIBBLER -DUDHCPC_RUN_IN_BACKGROUND"
-EXTRA_OECONF += "${@bb.utils.contains("DISTRO_FEATURES", "bridgeUtilsBin", " --enable-bridgeUtilsBin=yes ", " ", d)}"
+EXTRA_OECONF += "${@bb.utils.contains('DISTRO_FEATURES', 'bridgeUtilsBin', ' --enable-bridgeUtilsBin=yes ', '', d)}"
 
 CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '-DRDK_ONEWIFI', '', d)}"
 LDFLAGS_append = "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin',' -lOvsAgentApi ',' ',d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-misc.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-misc.bbappend
@@ -1,5 +1,21 @@
 include ccsp_common_bananapi.inc
+inherit breakpad-wrapper
 
 CFLAGS_aarch64_append = "-Werror=format-truncation=1"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','halinterface','',d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','hal-bridgeutil','',d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','breakpad','',d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','breakpad-wrapper','',d)}"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','ovs-agent','',d)}"
 
 CFLAGS += " -DDHCPV4_CLIENT_UDHCPC -DDHCPV6_CLIENT_DIBBLER -DUDHCPC_RUN_IN_BACKGROUND"
+EXTRA_OECONF += "${@bb.utils.contains("DISTRO_FEATURES", "bridgeUtilsBin", " --enable-bridgeUtilsBin=yes ", " ", d)}"
+
+CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', '-DRDK_ONEWIFI', '', d)}"
+LDFLAGS_append = "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin',' -lOvsAgentApi ',' ',d)}"
+
+BREAKPAD_BIN_append = "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','bridgeUtils','',d)}"
+
+# generating minidumps
+
+PACKAGECONFIG_append = "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin','breakpad',' ',d)}"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_banana.xml
@@ -317,7 +317,7 @@
   <Record name="dmsb.l2net.1.InstanceNum" type="astr">1</Record>
   <Record name="dmsb.l2net.1.Type" type="astr">Bridge</Record>
   <Record name="dmsb.l2net.1.Members.SW" type="astr">sw_1 sw_2 sw_3 sw_4 sw_5</Record>
-  <Record name="dmsb.l2net.1.Members.Eth" type="astr"> </Record>
+  <Record name="dmsb.l2net.1.Members.Eth" type="astr">lan1 lan2 lan3</Record>
   <Record name="dmsb.l2net.1.Members.Moca" type="astr"> </Record>
   <Record name="dmsb.l2net.1.Members.Gre" type="astr"> </Record>
   <Record name="dmsb.l2net.1.Members.WiFi" type="astr">ath0 ath1</Record>

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp_common_bananapi.inc
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp_common_bananapi.inc
@@ -14,6 +14,7 @@ CFLAGS_append  += " ${@bb.utils.contains('DISTRO_FEATURES', 'WanFailOverSupportE
 CFLAGS_append  += " ${@bb.utils.contains('DISTRO_FEATURES', 'WanManagerUnificationEnable', '-DWAN_MANAGER_UNIFICATION_ENABLED', '', d)}"
 CFLAGS_append += "${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', ' -DFEATURE_RDKB_WAN_MANAGER ', '', d)}"
 CFLAGS_append  += " ${@bb.utils.contains('DISTRO_FEATURES', 'dhcp_manager', '-DFEATURE_RDKB_DHCP_MANAGER', '', d)}"
+CFLAGS_append += "${@bb.utils.contains('DISTRO_FEATURES','bridgeUtilsBin',' -D_BRIDGE_UTILS_BIN_ ','',d)}"
 
 DEPENDS += "breakpad-wrapper"
 LDFLAGS += "-lbreakpadwrapper"

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia.bbappend
@@ -88,6 +88,9 @@ echo "#SelfHeal
 #TR069support
 \$EnableTR69Binary=true
 
+#bridgeUtils support
+\$bridge_util_enable=true
+
 #Enablemaptconfig
 \@mapt_config_flag=set
 

--- a/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/service_bridge_bpi.sh
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/util/utopia/service_bridge_bpi.sh
@@ -627,6 +627,13 @@ del_from_group()
 
   echo "brctl delif brlan0 l$cmdiag_if $wan_if"
   brctl delif brlan0 l$cmdiag_if "$wan_if"
+
+  bridge_curr_status=`ifconfig -a brlan0 | grep "inet addr" | cut -d ':' -f2 | cut -d ' ' -f1`
+  lan_ipaddr=`syscfg get lan_ipaddr`
+  lan_netmask=`syscfg get lan_netmask`
+  if [ -z "$bridge_curr_status" ]; then
+     ifconfig "$bridge_name" "$lan_ipaddr" netmask "$lan_netmask" up
+  fi
 }
 
 filter_local_traffic()


### PR DESCRIPTION
Reason for change :
1) Enabling bridgeutils in BPI.
2) Added necessary changes to support bridgeUtils binary.

Test Procedure: Verify bridge mode functionality is is working or not.
Risks: None